### PR TITLE
More width choices for list-leave-behind.

### DIFF
--- a/css/_list.scss
+++ b/css/_list.scss
@@ -26,7 +26,7 @@
 //	</li>
 //	<li>
 //		List Item 3
-//		<div class="wfm-leave-behind">
+//		<div class="wfm-leave-behind wfm-leave-behind-1">
 //			<span>
 //				<i class="mdi mdi-delete"></i>
 //			</span>
@@ -109,7 +109,20 @@
 		margin:0 5px;
 	}
 }
-
 .wfm-list li:hover > .wfm-leave-behind {
 	width: 110px;
+}
+.wfm-list li:hover > {
+	.wfm-leave-behind.wfm-leave-behind-1 {
+		width: 40px;
+	}
+	.wfm-leave-behind.wfm-leave-behind-2 {
+		width: 75px;
+	}
+	.wfm-leave-behind.wfm-leave-behind-3 {
+		width: 110px;
+	}
+	.wfm-leave-behind.wfm-leave-behind-4 {
+		width: 145px;
+	}
 }


### PR DESCRIPTION
We may need different widths for wfm-leave-behind depending on the number of buttons to include.

Usage example:
```
<div class="wfm-leave-behind wfm-leave-behind-1">
```
for leave-behind with only 1 button.