### PR TITLE
Add style for "select all" checkbox in ui-grid header

### DIFF
--- a/css/_tables.scss
+++ b/css/_tables.scss
@@ -168,6 +168,10 @@
 	content: "\f1d6"!important;
 }
 
+.ui-grid-all-selected.ui-grid-icon-ok:before  {
+	content: "\f1da"!important;
+}
+
 .ui-grid-row-selected .ui-grid-icon-ok:before  {
 	content: "\f1da"!important;
 }


### PR DESCRIPTION
Add a class for "select all" checkbox in ui grid header, refer to bug #34221: When I check all in web people, the box on behalf all is not checked.