### PR TITLE
Remove padding for ui grid menu item.

### DIFF
--- a/css/_tables.scss
+++ b/css/_tables.scss
@@ -139,9 +139,6 @@
 .ui-grid-menu .ui-grid-menu-inner ul li:hover, .ui-grid-menu .ui-grid-menu-inner ul li.ui-grid-menu-item-active{
 	box-shadow:none;
 }
-.ui-grid-menu .ui-grid-menu-inner ul li{
-	padding: $full-padding;
-}
 
 .ui-grid-selection-row-header-buttons{
 	opacity: 1; 


### PR DESCRIPTION
Hi Carl，
This is the strange padding I mentioned in the mail that breaks the ui grid menu style.
Here I just remove it to make the original style from ui grid work.
Please check if there is anything inappropriate.

Chundan