### PR TITLE
Time range picker custom template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ css/main.min.css
 dist/
 css/main_dark.min.css
 css/main_dark.css
-.html.js
+*.html.js

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ css/main.min.css
 dist/
 css/main_dark.min.css
 css/main_dark.css
+.html.js

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,5 @@
 {
-    "excludeFiles": ["node_modules/**", "bower_components/**"],
+    "excludeFiles": ["node_modules/**", "bower_components/**", "templates/**/*.html.js"],
 
     "requireCurlyBraces": [
         "if",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,5 +113,5 @@ module.exports = function(grunt) {
     grunt.registerTask('default', ['dist', 'watch:styleguide']);
     grunt.registerTask('before-test', ['html2js']);
     grunt.registerTask('test', ['before-test', 'karma:styleguide']);
-    grunt.registerTask('dist', ['jscs', 'jshint', 'ngtemplates', 'sass:styleguide', 'sass:dist', 'shell', 'cssmin', 'uglify']); // this task is kind of package
+    grunt.registerTask('dist', ['jscs', 'jshint', 'ngtemplates', 'sass:styleguide', 'sass:dist', 'shell', 'cssmin', 'uglify', 'html2js']); // this task is kind of package
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,23 @@
               },
         uglify: {
                   'dist/wfmdirectives.min.js': ['directives/**/*.js', '!directives/**/*.spec.js']
-              }
+              },
+      html2js: {
+        dist: {
+          options: {
+            module: null,
+            base: '.',
+            rename: function(moduleName) {
+              return `${moduleName}`;
+            }
+          },
+          files: [{
+            expand: true,
+            src: ['directives/**/*.tpl.html'],
+            ext: '.html.js'
+          }]
+        }
+      }
     });
 
      grunt.loadNpmTasks('grunt-sass');
@@ -90,9 +106,11 @@
      grunt.loadNpmTasks('grunt-jscs');
      grunt.loadNpmTasks('grunt-contrib-uglify');
      grunt.loadNpmTasks('grunt-angular-templates');
+     grunt.loadNpmTasks('grunt-html2js');
 
      // Default task(s).
      grunt.registerTask('default', ['dist', 'watch:styleguide']);
-     grunt.registerTask('test', ['karma:styleguide']);
+     grunt.registerTask('before-test', ['html2js']);
+     grunt.registerTask('test', ['before-test', 'karma:styleguide']);
      grunt.registerTask('dist', ['jscs', 'jshint', 'ngtemplates', 'sass:styleguide', 'sass:dist', 'shell', 'cssmin', 'uglify']); // this task is kind of package
  };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
- module.exports = function(grunt) {
+module.exports = function(grunt) {
 
-     grunt.initConfig({
+    grunt.initConfig({
         sass: {
             dist: {
                 files: {
@@ -71,46 +71,47 @@
             }
         },
         sasslint: {
-                  options: {
-                      configFile: 'config/.sass-lint.yml',
-                  },
-                  target: ['location/*.scss']
-              },
+            options: {
+                configFile: 'config/.sass-lint.yml',
+            },
+            target: ['location/*.scss']
+        },
         uglify: {
-                  'dist/wfmdirectives.min.js': ['directives/**/*.js', '!directives/**/*.spec.js']
-              },
-      html2js: {
-        dist: {
-          options: {
-            module: null,
-            base: '.',
-            rename: function(moduleName) {
-              return `${moduleName}`;
+            'dist/wfmdirectives.min.js': ['directives/**/*.js', '!directives/**/*.spec.js']
+        },
+        html2js: {
+            dist: {
+                options: {
+                    module: null,
+                    base: '.',
+                    rename: function(moduleName) {
+                        return moduleName;
+                    }
+                },
+                files: [{
+                    expand: true,
+                    src: ['directives/**/*.tpl.html'],
+                    dest: 'templates/',
+                    ext: '.html.js'
+                }]
             }
-          },
-          files: [{
-            expand: true,
-            src: ['directives/**/*.tpl.html'],
-            ext: '.html.js'
-          }]
         }
-      }
     });
 
-     grunt.loadNpmTasks('grunt-sass');
-     grunt.loadNpmTasks('grunt-contrib-watch');
-     grunt.loadNpmTasks('grunt-shell');
-     grunt.loadNpmTasks('grunt-contrib-cssmin');
-     grunt.loadNpmTasks('grunt-karma');
-     grunt.loadNpmTasks('grunt-contrib-jshint');
-     grunt.loadNpmTasks('grunt-jscs');
-     grunt.loadNpmTasks('grunt-contrib-uglify');
-     grunt.loadNpmTasks('grunt-angular-templates');
-     grunt.loadNpmTasks('grunt-html2js');
+    grunt.loadNpmTasks('grunt-sass');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-shell');
+    grunt.loadNpmTasks('grunt-contrib-cssmin');
+    grunt.loadNpmTasks('grunt-karma');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-jscs');
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-angular-templates');
+    grunt.loadNpmTasks('grunt-html2js');
 
-     // Default task(s).
-     grunt.registerTask('default', ['dist', 'watch:styleguide']);
-     grunt.registerTask('before-test', ['html2js']);
-     grunt.registerTask('test', ['before-test', 'karma:styleguide']);
-     grunt.registerTask('dist', ['jscs', 'jshint', 'ngtemplates', 'sass:styleguide', 'sass:dist', 'shell', 'cssmin', 'uglify']); // this task is kind of package
- };
+    // Default task(s).
+    grunt.registerTask('default', ['dist', 'watch:styleguide']);
+    grunt.registerTask('before-test', ['html2js']);
+    grunt.registerTask('test', ['before-test', 'karma:styleguide']);
+    grunt.registerTask('dist', ['jscs', 'jshint', 'ngtemplates', 'sass:styleguide', 'sass:dist', 'shell', 'cssmin', 'uglify']); // this task is kind of package
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,5 +113,5 @@ module.exports = function(grunt) {
     grunt.registerTask('default', ['dist', 'watch:styleguide']);
     grunt.registerTask('before-test', ['html2js']);
     grunt.registerTask('test', ['before-test', 'karma:styleguide']);
-    grunt.registerTask('dist', ['jscs', 'jshint', 'ngtemplates', 'sass:styleguide', 'sass:dist', 'shell', 'cssmin', 'uglify', 'html2js']); // this task is kind of package
+    grunt.registerTask('dist', ['jscs', 'jshint', 'ngtemplates', 'sass:styleguide', 'sass:dist', 'shell', 'cssmin', 'html2js', 'uglify']); // this task is kind of package
 };

--- a/directives/time-range-picker/time-range-picker.directive.js
+++ b/directives/time-range-picker/time-range-picker.directive.js
@@ -1,7 +1,7 @@
 (function() {
 
     'use strict';
-    
+
     var wfmTimeRangePickerConfig = {
         showMeridian: true,
         templateUrl: 'directives/time-range-picker/time-range-picker.tpl.html',
@@ -11,11 +11,11 @@
            .constant('wfmTimeRangePickerConfig', wfmTimeRangePickerConfig)
            .directive('timepickerWrap', [timepickerWrap])
            .directive('timeRangePicker', ['$filter', 'wfmTimeRangePickerConfig', timeRangePicker]);
-           
+
     function timeRangePicker($filter, wfmTimeRangePickerConfig) {
         return {
             templateUrl: function(element, attrs) {
-                return attrs.templateUrl || wfmTimeRangePickerConfig.templateUrl
+                return attrs.templateUrl || wfmTimeRangePickerConfig.templateUrl;
             },
             scope: {
                 startTime: '=',

--- a/directives/time-range-picker/time-range-picker.directive.js
+++ b/directives/time-range-picker/time-range-picker.directive.js
@@ -1,14 +1,22 @@
 (function() {
 
     'use strict';
+    
+    var wfmTimeRangePickerConfig = {
+        showMeridian: true,
+        templateUrl: 'directives/time-range-picker/time-range-picker.tpl.html',
+    };
 
     angular.module('wfm.timerangepicker', [])
+           .constant('wfmTimeRangePickerConfig', wfmTimeRangePickerConfig)
            .directive('timepickerWrap', [timepickerWrap])
-           .directive('timeRangePicker', ['$filter', timeRangePicker]);
-
-    function timeRangePicker($filter) {
+           .directive('timeRangePicker', ['$filter', 'wfmTimeRangePickerConfig', timeRangePicker]);
+           
+    function timeRangePicker($filter, wfmTimeRangePickerConfig) {
         return {
-            template: getHtmlTemplate(),
+            templateUrl: function(element, attrs) {
+                return attrs.templateUrl || wfmTimeRangePickerConfig.templateUrl
+            },
             scope: {
                 startTime: '=',
                 endTime: '=',

--- a/directives/time-range-picker/time-range-picker.directive.spec.js
+++ b/directives/time-range-picker/time-range-picker.directive.spec.js
@@ -13,9 +13,9 @@ describe('time-range-picker directive', function() {
         $rootScope = _$rootScope_;
         $compile = _$compile_;
         $templateCache = _$templateCache_;
-        
+
         element = $compile('<time-range-picker></time-range-picker>')($rootScope);
-        
+
         scope = $rootScope.$new();
         scope.startTime = moment({hour: 8, minute: 30}).toDate();
         scope.endTime = moment({hour: 17, minute: 30}).toDate();
@@ -29,13 +29,13 @@ describe('time-range-picker directive', function() {
         scope.$apply();
         expect(element).toBeDefined();
     });
-    
+
     describe('custom template', function() {
         it('should allow custom templates', function() {
             $templateCache.put('foo/bar.html', '<div class="custom-template">baz</div>');
             element = $compile('<time-range-picker template-url="foo/bar.html"></time-range-picker>')($rootScope);
             $rootScope.$digest();
-            
+
             expect(element.children().hasClass('custom-template')).toBeTruthy();
             expect(element.children().html()).toBe('baz');
         });

--- a/directives/time-range-picker/time-range-picker.directive.spec.js
+++ b/directives/time-range-picker/time-range-picker.directive.spec.js
@@ -1,10 +1,21 @@
 describe('time-range-picker directive', function() {
     var elementCompileFn,
-        scope;
+        scope,
+        element,
+        $rootScope,
+        $compile,
+        $templateCache;
 
     beforeEach(module('wfm.timerangepicker'));
+    beforeEach(module('directives/time-range-picker/time-range-picker.tpl.html'));
 
-    beforeEach(inject(function($compile, $rootScope) {
+    beforeEach(inject(function(_$compile_, _$rootScope_, _$templateCache_) {
+        $rootScope = _$rootScope_;
+        $compile = _$compile_;
+        $templateCache = _$templateCache_;
+        
+        element = $compile('<time-range-picker></time-range-picker>')($rootScope);
+        
         scope = $rootScope.$new();
         scope.startTime = moment({hour: 8, minute: 30}).toDate();
         scope.endTime = moment({hour: 17, minute: 30}).toDate();
@@ -18,9 +29,21 @@ describe('time-range-picker directive', function() {
         scope.$apply();
         expect(element).toBeDefined();
     });
+    
+    describe('custom template', function() {
+        it('should allow custom templates', function() {
+            $templateCache.put('foo/bar.html', '<div class="custom-template">baz</div>');
+            element = $compile('<time-range-picker template-url="foo/bar.html"></time-range-picker>')($rootScope);
+            $rootScope.$digest();
+            
+            expect(element.children().hasClass('custom-template')).toBeTruthy();
+            expect(element.children().html()).toBe('baz');
+        });
+    });
 
     it('Should show timepickers for start-time and end-time', function() {
         var element = elementCompileFn()(scope);
+        scope.$apply();
         var timepickers = element.find('timepicker-wrap');
         expect(timepickers.length).toEqual(2);
     });
@@ -67,6 +90,7 @@ describe('time-range-picker directive', function() {
     it('Should not show meridian in Swedish time-format', function() {
         moment.locale('sv');
         var element = elementCompileFn()(scope);
+        scope.$apply();
         var timepicker = angular.element(element.find('timepicker-wrap')[0]);
         expect(timepicker.scope().showMeridian).toBeFalsy();
 
@@ -75,6 +99,7 @@ describe('time-range-picker directive', function() {
     it('Should show meridian in US time-format', function() {
         moment.locale('en-US');
         var element = elementCompileFn()(scope);
+        scope.$apply();
         var timepicker = angular.element(element.find('timepicker-wrap')[0]);
         expect(timepicker.scope().showMeridian).toBeTruthy();
 

--- a/directives/time-range-picker/time-range-picker.tpl.html
+++ b/directives/time-range-picker/time-range-picker.tpl.html
@@ -1,0 +1,23 @@
+<div ng-class="{'ng-valid': !isInvalid(), 'ng-invalid': isInvalid(), 'ng-invalid-order': isInvalid('order'), 'ng-invalid-empty': isInvalid('empty')}">
+    <table>
+        <tr>
+            <td>
+                <ng-transclude></ng-transclude>
+            </td>
+            <td>
+                <timepicker-wrap ng-model="startTime"></timepicker>
+            </td>
+            <td> <i class="mdi mdi-minus"> </i> </td>
+            <td>
+                <timepicker-wrap ng-model="endTime"></timepicker>
+            </td>
+            <td>
+                <div class="next-day-toggle" ng-show="!disableNextDay || nextDay">
+                    <button class="wfm-btn wfm-btn-invis-default" ng-class="{'wfm-btn-invis-disabled': disableNextDay }" ng-click="toggleNextDay()">{{nextDayToggleText}}</button>
+                </div>
+            </td>
+        </tr>
+    </table>
+</div>
+<div class="error-msg-container ng-invalid-order alert-error notice-spacer" ng-if="showMessage"><i class='mdi mdi-alert-octagon'></i> <span translate>EndTimeMustBeGreaterOrEqualToStartTime</span></div>
+<div class="error-msg-container ng-invalid-empty alert-error notice-spacer" ng-if="showMessage"><i class='mdi mdi-alert-octagon'></i> <span translate>StartTimeAndEndTimeMustBeSet</span></div>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,6 +27,8 @@ module.exports = function(config) {
 
         // list of files to exclude
         exclude: [
+            'directives/time-range-picker/uib-timepicker.ref.js',
+            'directives/time-range-picker/timepicker.ref.js'
         ],
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,7 +21,8 @@ module.exports = function(config) {
           'node_modules/angular-mocks/angular-mocks.js',
           'node_modules/angular-ui-bootstrap/ui-bootstrap.min.js',
           'dist/templates.js',
-          'directives/**/*.js'
+          'directives/**/*.js',
+          'templates/**/*.html.js'
         ],
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,8 +27,6 @@ module.exports = function(config) {
 
         // list of files to exclude
         exclude: [
-            'directives/time-range-picker/uib-timepicker.ref.js',
-            'directives/time-range-picker/timepicker.ref.js'
         ],
 
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "url": "git://github.com/Teleopti/styleguide.git"
   },
   "scripts": {
-	"test": "grunt test",
-	"start": "grunt",
-	"dist": "grunt dist",
-	"kss": "./node_modules/.bin/kss-node css styleguide css/styleguide.md --template kss-template --verbose"
-},
+    "test": "grunt test",
+    "start": "grunt",
+    "dist": "grunt dist",
+    "kss": "./node_modules/.bin/kss-node css styleguide css/styleguide.md --template kss-template --verbose"
+  },
   "description": "Styleguide for Teleopti",
   "author": "Teleopti",
   "license": "ISC",
@@ -30,11 +30,12 @@
   "devDependencies": {
     "angular-mocks": "1.4.7",
     "grunt": "0.4.5",
-    "grunt-angular-templates": "1.0.3",
+    "grunt-angular-templates": "0.5.7",
     "grunt-contrib-cssmin": "0.12.2",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-uglify": "0.11.1  ",
     "grunt-contrib-watch": "0.6.1",
+    "grunt-html2js": "^0.3.5",
     "grunt-jscs": "2.3.0",
     "grunt-karma": "0.12.0",
     "grunt-sass": "1.1.0",
@@ -47,7 +48,6 @@
     "karma-jasmine": "0.3.6",
     "karma-phantomjs-launcher": "1.0.0",
     "kss": "2.4.0",
-    "grunt-angular-templates": "0.5.7",
     "phantomjs2": "2.2.0"
   },
   "homepage": "http://teleopti.github.io/styleguide/styleguide"


### PR DESCRIPTION
Now you can use a different template via the `template-url` attribute. 

For testing purpose, `html2js` is introduced to the build system. HTML Templates will be converted to JS files (Angular modules, to be exact) in the `templates` directory. This way, we can test the directive with default or custom templates. 

A `grunt test` shows all tests are passed, but please let me know if there is any problem. 