### PR TITLE
Use $locale rather than moment to get locale info

### DIFF
--- a/directives/time-range-picker/time-range-picker.directive.js
+++ b/directives/time-range-picker/time-range-picker.directive.js
@@ -3,7 +3,7 @@
     'use strict';
 
     angular.module('wfm.timerangepicker', [])
-           .directive('timepickerWrap', [timepickerWrap])
+           .directive('timepickerWrap', ['$locale', timepickerWrap])
            .directive('timeRangePicker', ['$filter', timeRangePicker]);
 
     var defaultTemplate = 'directives/time-range-picker/time-range-picker.tpl.html';
@@ -148,9 +148,8 @@
         }
     }
 
-    function timepickerWrap() {
-
-        var meridianInfo = getMeridiemInfoFromMoment();
+    function timepickerWrap($locale) {
+        var meridianInfo = getMeridiemInfoByLocale($locale);
 
         return {
             template: '<timepicker></timepicker>',
@@ -183,14 +182,14 @@
 
     }
 
-    function getMeridiemInfoFromMoment() {
-        var timeFormat = moment.localeData()._longDateFormat.LT;
+    function getMeridiemInfoByLocale($locale) {
+        var timeFormat = $locale.DATETIME_FORMATS.shortTime;
         var info = {};
 
         if (/h:/.test(timeFormat)) {
             info.showMeridian = true;
-            info.am = moment.localeData().meridiem(9, 0);
-            info.pm = moment.localeData().meridiem(15, 0);
+            info.am = $locale.DATETIME_FORMATS.AMPMS[0];
+            info.pm = $locale.DATETIME_FORMATS.AMPMS[1];
         } else {
             info.showMeridian = false;
         }

--- a/directives/time-range-picker/time-range-picker.directive.spec.js
+++ b/directives/time-range-picker/time-range-picker.directive.spec.js
@@ -4,6 +4,10 @@ describe('time-range-picker directive', function() {
         scope;
 
     beforeEach(module('styleguide.templates'));
+    beforeEach(module('tmh.dynamicLocale'));
+    beforeEach(module(function(tmhDynamicLocaleProvider) {
+        tmhDynamicLocaleProvider.localeLocationPattern('/base/node_modules/angular-i18n/angular-locale_{{locale}}.js');
+    }));
     beforeEach(module('wfm.timerangepicker'));
 
     beforeEach(inject(function(_$compile_, _$rootScope_, _$templateCache_) {
@@ -80,22 +84,45 @@ describe('time-range-picker directive', function() {
         expect(validityDiv.scope().nextDay).toBeTruthy();
     });
 
-    it('Should not show meridian in Swedish time-format', function() {
-        moment.locale('sv');
-        var element = elementCompileFn()(scope);
-        scope.$apply();
-        var timepicker = angular.element(element.find('timepicker-wrap')[0]);
-        expect(timepicker.scope().showMeridian).toBeFalsy();
+    describe('l10n', function() {
+        it('should be able to change locale', function(done) {
+            inject(['$locale', 'tmhDynamicLocale', function($locale, tmhDynamicLocale) {
+                tmhDynamicLocale.set('sv').then(function(locale) {
+                    expect($locale.id).toBe('sv');
+                    expect($locale['DATETIME_FORMATS']['shortTime']).toBe('HH:mm');
+                    done();
+                });
+            }]);
+        });
 
-    });
+        it('Should not show meridian in Swedish time-format', function(done) {
+            inject(['tmhDynamicLocale', function(tmhDynamicLocale) {
+                tmhDynamicLocale.set('sv').then(function(locale) {
+                    // use timeout to avoid crashing digest loop
+                    setTimeout(function() {
+                        var element = elementCompileFn()(scope);
+                        scope.$apply();
+                        var timepicker = angular.element(element.find('timepicker-wrap')[0]);
+                        expect(timepicker.scope().showMeridian).toBeFalsy();
+                        done();
+                    }, 200);
+                });
+            }]);
+        });
 
-    it('Should show meridian in US time-format', function() {
-        moment.locale('en-US');
-        var element = elementCompileFn()(scope);
-        scope.$apply();
-        var timepicker = angular.element(element.find('timepicker-wrap')[0]);
-        expect(timepicker.scope().showMeridian).toBeTruthy();
-
+        it('Should show meridian in US time-format', function(done) {
+            inject(['$locale', 'tmhDynamicLocale', function($locale, tmhDynamicLocale) {
+                tmhDynamicLocale.set('zh-cn').then(function(locale) {
+                    setTimeout(function() {
+                        var element = elementCompileFn()(scope);
+                        scope.$apply();
+                        var timepicker = angular.element(element.find('timepicker-wrap')[0]);
+                        expect(timepicker.scope().showMeridian).toBeTruthy();
+                        done();
+                    }, 200);
+                });
+            }]);
+        });
     });
 
     it('Setting next day to true will change the end-time to different date value', function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,6 @@ module.exports = function(config) {
         // base path that will be used to resolve all patterns (eg. files, exclude)
         basePath: '',
 
-
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
         frameworks: ['jasmine'],
@@ -20,15 +19,20 @@ module.exports = function(config) {
           'node_modules/angular-moment/angular-moment.min.js',
           'node_modules/angular-mocks/angular-mocks.js',
           'node_modules/angular-ui-bootstrap/ui-bootstrap.min.js',
+          'node_modules/angular-dynamic-locale/dist/tmhDynamicLocale.js',
+          {
+              pattern: 'node_modules/angular-i18n/angular-locale_*.js',
+              watched: false,
+              included: false,
+              served: true
+          },
           'dist/templates.js',
           'directives/**/*.js'
         ],
 
-
         // list of files to exclude
         exclude: [
         ],
-
 
         // preprocess matching files before serving them to the browser
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "devDependencies": {
     "angular-mocks": "1.4.7",
     "grunt": "0.4.5",
-    "grunt-angular-templates": "^1.0.3",
     "grunt-contrib-cssmin": "0.12.2",
+    "grunt-angular-templates": "^1.0.3",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-uglify": "0.11.1  ",
     "grunt-contrib-watch": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "devDependencies": {
     "angular-mocks": "1.4.7",
     "grunt": "0.4.5",
+    "grunt-angular-templates": "1.0.3",
     "grunt-contrib-cssmin": "0.12.2",
-    "grunt-angular-templates": "^1.0.3",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-uglify": "0.11.1  ",
     "grunt-contrib-watch": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "angular-mocks": "1.4.7",
     "grunt": "0.4.5",
-    "grunt-angular-templates": "0.5.7",
+    "grunt-angular-templates": "^1.0.3",
     "grunt-contrib-cssmin": "0.12.2",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-uglify": "0.11.1  ",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "url": "git://github.com/Teleopti/styleguide.git"
   },
   "scripts": {
-	"test": "grunt test",
-	"start": "grunt",
-	"dist": "grunt dist",
-	"kss": "./node_modules/.bin/kss-node css styleguide css/styleguide.md --template kss-template --verbose"
-},
+    "test": "grunt test",
+    "start": "grunt",
+    "dist": "grunt dist",
+    "kss": "./node_modules/.bin/kss-node css styleguide css/styleguide.md --template kss-template --verbose"
+  },
   "description": "Styleguide for Teleopti",
   "author": "Teleopti",
   "license": "ISC",
@@ -18,11 +18,13 @@
     "angular": "1.4.7",
     "angular-animate": "1.4.7",
     "angular-aria": "1.4.7",
+    "angular-dynamic-locale": "^0.1.30",
+    "angular-i18n": "^1.5.3",
     "angular-material": "1.0.5",
     "angular-moment": "0.8.3",
-    "angular-ui-bootstrap": "0.14.3",
-    "angular-translate": "2.7.2",
     "angular-route": "1.4.7",
+    "angular-translate": "2.7.2",
+    "angular-ui-bootstrap": "0.14.3",
     "angular-ui-tree": "2.10.0",
     "bootstrap": "3.2.0",
     "moment": "2.8.3"
@@ -30,7 +32,7 @@
   "devDependencies": {
     "angular-mocks": "1.4.7",
     "grunt": "0.4.5",
-    "grunt-angular-templates": "1.0.3",
+    "grunt-angular-templates": "0.5.7",
     "grunt-contrib-cssmin": "0.12.2",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-uglify": "0.11.1  ",
@@ -47,7 +49,6 @@
     "karma-jasmine": "0.3.6",
     "karma-phantomjs-launcher": "1.0.0",
     "kss": "2.4.0",
-    "grunt-angular-templates": "0.5.7",
     "phantomjs2": "2.2.0"
   },
   "homepage": "http://teleopti.github.io/styleguide/styleguide"


### PR DESCRIPTION
In this PR, the Time Range Picker will look for locale info from `$locale` rather than `moment` on the global. 

`Angular-i18n` is introduced to provide locale files. And `angular-dynamic-locale` is also imported in testing in order to switch locale. 