### PR TITLE
Specify colors for sidenav in dark theme

### DIFF
--- a/css/_sidenavs.scss
+++ b/css/_sidenavs.scss
@@ -110,3 +110,14 @@
     margin-right: 10px!important;
     margin-left: 5px!important;
 }
+
+md-sidenav {
+	md-content {
+		background-color: $white !important;
+		color: $gray087;
+
+		option {
+			background-color: $white;
+		}
+	}
+}

--- a/css/_sidenavs.scss
+++ b/css/_sidenavs.scss
@@ -111,13 +111,11 @@
     margin-left: 5px!important;
 }
 
-md-sidenav {
-	md-content {
-		background-color: $white !important;
-		color: $gray087;
+.command-panel-content {
+	background-color: $white !important;
+	color: $gray087;
+}
 
-		option {
-			background-color: $white;
-		}
-	}
+.command-panel-option {
+	background-color: $white;
 }


### PR DESCRIPTION
This PR fixes the issue that the background color of md-sidenav is white in the dark theme. 