### PR TITLE
Working Hours Picker: invalid date format

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,8 +118,8 @@
 
     /*Code for time range picker*/
     $scope.timeRange = {
-        startTime: new Date('2015-01-01 08:00:00'),
-        endTime: new Date('2015-01-01 17:00:00')
+        startTime: new Date(2016, 0, 1, 8),
+        endTime: new Date(2016, 0, 1, 17)
     };
     $scope.disableNextDay = false;
 

--- a/directives/workinghourspicker/working-hours-picker.directive.js
+++ b/directives/workinghourspicker/working-hours-picker.directive.js
@@ -41,8 +41,8 @@
         scope.toggleAllChecks = toggleAllChecks;
 
         scope.newWorkingPeriod = {
-            startTime: new Date('2015-01-01 08:00:00'),
-            endTime: new Date('2015-01-01 17:00:00')
+            startTime: new Date(2016, 0, 1, 8),
+            endTime: new Date(2016, 0, 1, 17)
         };
 
         scope.disableNextDay = true;


### PR DESCRIPTION
Instantiate the initial dates of the component in a standard way compatible with IE and Firefox. The previous format is supported by Chrome only. 