### PR TITLE
fix broken spinner

### DIFF
--- a/css/_loading.scss
+++ b/css/_loading.scss
@@ -42,22 +42,22 @@ md-progress-linear[md-mode=buffer]{
 //
 //Styleguide 1.16.2
 //
-md-progress-circular .md-inner .md-half-circle {
-  border-left-color: $pink-500!important;
-}
 
 md-progress-circular .md-inner .md-left .md-half-circle {
   border-left-color: $pink-500;
+  border-top-color: $pink-500;
 }
 
 md-progress-circular.md-default-theme .md-inner .md-left .md-half-circle,
 md-progress-circular.md-default-theme .md-inner .md-right .md-half-circle,
 md-progress-circular .md-inner .md-gap {
   border-top-color: $pink-500;
+  border-bottom-color: $pink-500;
 }
 
 md-progress-circular .md-inner .md-right .md-half-circle {
   border-right-color: $pink-500;
+  border-top-color: $pink-500;
 }
 
 //.mini-spinner {


### PR DESCRIPTION
fix broken spinner by adding color rules. maybe we could update angular material to 1.1.0, in which animation is smoother and theming is simpler. 