### PR TITLE
Let ui-bootstrap use ng-locale on its own.

### DIFF
--- a/directives/date-range-picker/date-range-picker.directive.js
+++ b/directives/date-range-picker/date-range-picker.directive.js
@@ -40,8 +40,7 @@
 
             scope.datepickerOptions = {
                 customClass: getDayClass,
-                showWeeks: true,
-                startingDay: $locale.DATETIME_FORMATS.FIRSTDAYOFWEEK
+                showWeeks: true
             };
 
             scope.defaultValidators = [


### PR DESCRIPTION
Remove the reduncant declaration for _the start day of week_, because `ui-bootstrap` use `ng-locale` internally.

On the other hand, since in `ng-locale`, 0 is used to stand
for *Monday*, but `ui-bootstrap` is expecting a value with js-standard, i.e. having 0 for *Sunday*, we need to increment the sdow by 1 to make the correct assignment.

[Ref](https://github.com/angular/angular.js/issues/11900) 