### PR TITLE
Right-panel trigger position

### DIFF
--- a/css/_rightpanel.scss
+++ b/css/_rightpanel.scss
@@ -21,8 +21,8 @@
 // Markup:
 //<div class="panel material-depth-1">
 //  <div class="sub-header">
-//    <span>Panel with sidebar</span>
-//		<wfm-right-panel panel-options="rightPanelOptions" class="head-actions">
+//    <h2>Panel with sidebar</h2>
+//		<wfm-right-panel panel-options="rightPanelOptions">
 //		  <div class="con-row">
 //		    <div class="con-flex">content</div>
 //		    </div>

--- a/directives/wfm-right-panel/wfm-right-panel.tpl.html
+++ b/directives/wfm-right-panel/wfm-right-panel.tpl.html
@@ -1,8 +1,10 @@
 <md-backdrop class="md-sidenav-backdrop md-opaque ng-scope" ng-if="vm.panelOptions.showBackdrop && vm.panelOptions.panelState" ng-click="vm.panelOptions.panelState = false;"></md-backdrop>
 
-<div tabindex=0 class="context-menu card-context open-right-panel" ng-if="vm.panelOptions.showPopupButton" ng-click="vm.panelOptions.panelState = true">
-	<i class="mdi mdi-chevron-double-left"></i>
-	<md-tooltip>{{"ShowRightPanel" | translate}}</md-tooltip>
+<div class="head-actions panel-menu">
+	<div tabindex=0 class="context-menu card-context open-right-panel" ng-if="vm.panelOptions.showPopupButton" ng-click="vm.panelOptions.panelState = true">
+	 <i class="mdi mdi-chevron-double-left"></i>
+	 <md-tooltip>{{"ShowRightPanel" | translate}}</md-tooltip>
+	</div>
 </div>
 
 <div resizable r-directions="['left']" r-flex="false" ng-show="vm.showPanel">


### PR DESCRIPTION
Moved the panel menu class inside the directive template. This might restrict the use of side-panels to be used only inside styleguide panel-containers but i see no issue there since that is the intended use at this point - if other uses are needed later we show examples of them in the styleguide when they appear

![image](https://cloud.githubusercontent.com/assets/5781286/21131788/e788342e-c110-11e6-8a00-d75082284c54.png)

![q2](https://cloud.githubusercontent.com/assets/5781286/21131945/c8d0ccb6-c111-11e6-902b-63ea80dda768.gif)

