### PR TITLE
Refresh styleguide ui

### DIFF
--- a/css/_chart.scss
+++ b/css/_chart.scss
@@ -4,28 +4,35 @@
 //A chart used to present complex data. We use <a href="http://c3js.org/gettingstarted.html">default C3</a> or the <a href="http://jettro.github.io/c3-angular-directive/#download">C3 chart directive</a> to get nice features like legends, zoom and period selection.
 //
 //Note: Column-values in the directive should be replaced with a variable to keep the html clean.
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
-//c3.generate({
-//		bindto: '#myChart',
-//		data: {
-//				columns: [
-//					['data1', 30, 200, 100, 400, 150, 250],
-//					['data2', 20, 180, 240, 100, 190, 0],
-//				],
-//				selection: {
-//						enabled: true,
-//				},
-//		},
-//		zoom: {
-//				enabled: true,
-//		},
-//});
-//		</pre></code>
-//	</div>
-//</div>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['chart'] = !showJs['chart']">
+//       <span ng-hide="showJs['chart']">Show</span>
+//      <span ng-show="showJs['chart']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['chart']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//         c3.generate({
+//       		bindto: '#myChart',
+//       		data: {
+//       				columns: [
+//       					['data1', 30, 200, 100, 400, 150, 250],
+//       					['data2', 20, 180, 240, 100, 190, 0],
+//       				],
+//       				selection: {
+//       						enabled: true,
+//       				},
+//       		},
+//       		zoom: {
+//       				enabled: true,
+//       		},
+//         });
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup:
 //	<h3>Bind to chart with zoom and select</h3>

--- a/css/_colors.scss
+++ b/css/_colors.scss
@@ -13,276 +13,58 @@
 //             <md-content class="md-padding classictheme-background">
 //               <div class="con-row">
 //                 <div class="con-flex">
-//                  Blue - Primary color
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 blue-100-swatch">
-//                           <p>$blue-100 #99D6FF</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 blue-300-swatch">
-//                           <p>$blue-300 #66C2FF</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 blue-500-swatch">
-//                           <p >$blue-500 #0099FF</p>
-//                     </li>
-//                   </ul>
-//                 Orange - Reserved for warnings
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 orange-400-swatch">
-//                           <p>$orange-400 #FFC285</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 orange-500-swatch">
-//                           <p>$orange-500 #FFA726</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 orange-600-swatch">
-//                           <p>$orange-600 #FB8C00</p>
-//                     </li>
-//                   </ul>
-//                 Red - Reserved for errors
-//                 <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 red-600-swatch">
-//                           <p>$red-600 #EE8F7D</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 red-700-swatch">
-//                           <p >$red-700 #EF5350</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 red-800-swatch">
-//                           <p >$red-800 #D32F2F</p>
-//                     </li>
-//                 </ul>
-//                 Green - Reserved for selection/success
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 green-100-swatch">
-//                           <p>$green-100 #C2E085</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 green-300-swatch">
-//                          <p>$green-300 #9CCC65</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 green-500-swatch">
-//                          <p>$green-500 #8BC34A</p>
-//                     </li>
-//                   </ul>
-//                 <div class="md-col6">
-//                 Pink
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 pink-100-swatch">
-//                           <p>$pink-100 #F8BBD0</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 pink-300-swatch">
-//                           <p >$pink-300 #F06292</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 pink-500-swatch">
-//                           <p >$pink-500 #E91E63</p>
-//                     </li>
-//                   </ul>
-//                 Purple
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 purple-100-swatch">
-//                           <p>$purple-100 #E1BEE7</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 purple-300-swatch">
-//                           <p >$purple-300 #BA68C8</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 purple-500-swatch">
-//                           <p >$purple-500 #9C27B0</p>
-//                     </li>
-//                   </ul>
-//                 Teal
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 teal-100-swatch">
-//                           <p>$teal-100 #B2DFDB</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 teal-300-swatch">
-//                           <p>$teal-300 #4DB6AC</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 teal-500-swatch">
-//                           <p >$teal-500 #009688</p>
-//                     </li>
-//                   </ul>
-//                 Brown
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 brown-100-swatch">
-//                           <p>$brown-100 #D7CCC8</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 brown-300-swatch">
-//                           <p >$brown-300 #A1887F</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 brown-500-swatch">
-//                           <p >$brown-500 #795548</p>
-//                     </li>
-//                   </ul>
-//                 Transparent Gray
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 white-swatch">
-//                           <p>$white <br> #ffffff</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 gray-012-swatch">
-//                           <p>$gray012 rgba(0,0,0,0.06)</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 gray-026-swatch">
-//                          <p>$gray026 rgba(0,0,0,0.26)</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 gray-054-swatch">
-//                           <p >$gray054 rgba(0,0,0,0.54)</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 gray-087-swatch">
-//                           <p class="white-color-text">$gray087 rgba(0,0,0,0.87)</p>
-//                     </li>
-//                   </ul>
-//                 Solid gray
-//                   <ul class="swatch-list">
-//                     <li class="spacer material-depth-1 gray-300-swatch">
-//                           <p>$gray-300 #E0E0E0</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 gray-500-swatch">
-//                           <p>$gray-500 #9E9E9E</p>
-//                     </li>
-//                     <li class="spacer material-depth-1 gray-100-swatch">
-//                           <p class="white-color-text">$gray100 rgba(0,0,0,1)</p>
-//                     </li>
-//                   </ul>
-//                 </div>
+//                  <div class="con-fluid-row swatch-list">
+//                    <div class="con-fluid-flex" style="border:none" ng-repeat="swatch in classicSwatches">
+//                      <div class="card panel swatch">
+//                        <div ng-class="swatch.Class">
+//                          <div class="spacer"></div>
+//                        </div>
+//                        <div class="card-footer con-row">
+//                          <div class="con-flex">
+//                            <article>
+//                              <b ng-bind="swatch.Variable"></b></br>
+//                              Used for <span ng-bind="swatch.Use"></span></br>
+//                              Code: <span ng-bind="swatch.Color"></span> </br>
+//                              Text color: <span ng-bind="swatch.TextColor"></span>
+//                            </article>
+//                          </div>
+//                        </div>
+//                      </div>
+//                    </div>
+//                   </div>
 //               </div>
 //             </md-content>
 //           </md-tab>
 //           <md-tab label="Dark Theme Colors">
 //             <md-content class="md-padding darktheme-background" >
 //               <div class="con-row">
-//             <div class="con-flex">
-//             <p>Blue - Primary color</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 blue-100-swatch-dark">
-//                       <p class="white-color-text">$blue-100 #1d5a83</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 blue-300-swatch-dark">
-//                       <p class="white-color-text">$blue-300 #136fac</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 blue-500-swatch-dark">
-//                       <p class="white-color-text">$blue-500 #0a84d6</p>
-//                 </li>
-//               </ul>
-//             <p>Orange - Reserved for warnings</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 orange-400-swatch-dark">
-//                       <p>$orange-400 #c27c36</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 orange-500-swatch-dark">
-//                       <p>$orange-500 #d68636</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 orange-600-swatch-dark">
-//                       <p>$orange-600 #ea9036</p>
-//                 </li>
-//               </ul>
-//            <p>Red - Reserved for errors</p>
-//             <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 red-600-swatch-dark">
-//                       <p>$red-600 <br>#ca3333</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 red-700-swatch-dark">
-//                       <p>$red-700  #EF5350</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 red-800-swatch-dark">
-//                       <p class="white-color-text">$red-800 <br> #ee8f7d</p>
-//                 </li>
-//             </ul>
-//             <p>Green - Reserved for selection/success</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 green-100-swatch-dark">
-//                       <p>$green-100 #627b32</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 green-300-swatch-dark">
-//                      <p>$green-300 #6f8e32</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 green-500-swatch-dark">
-//                      <p>$green-500 #84ad32</p>
-//                 </li>
-//               </ul>
-//             <div class="md-col6">
-//           <p>Pink</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 pink-100-swatch-dark">
-//                       <p>$pink-100 #E91E63</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 pink-300-swatch-dark">
-//                       <p class="white-color-text">$pink-300 #F06292</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 pink-500-swatch-dark">
-//                       <p class="white-color-text">$pink-500 #F8BBD0</p>
-//                 </li>
-//               </ul>
-//             <p>Purple</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 purple-100-swatch-dark">
-//                       <p>$purple-100 #9C27B0</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 purple-300-swatch-dark">
-//                       <p class="white-color-text">$purple-300 #BA68C8</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 purple-500-swatch-dark">
-//                       <p class="white-color-text">$purple-500 #E1BEE7</p>
-//                 </li>
-//               </ul>
-//             <p>Teal</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 teal-100-swatch-dark">
-//                       <p>$teal-100 #B2DFDB</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 teal-300-swatch-dark">
-//                       <p>$teal-300 #4DB6AC</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 teal-500-swatch-dark">
-//                       <p class="white-color-text">$teal-500 #009688</p>
-//                 </li>
-//               </ul>
-//            <p> Brown</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 brown-100-swatch-dark">
-//                       <p>$brown-100 #795548</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 brown-300-swatch-dark">
-//                       <p class="white-color-text">$brown-300 #A1887F</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 brown-500-swatch-dark">
-//                       <p class="white-color-text">$brown-500 #D7CCC8</p>
-//                 </li>
-//               </ul>
-//            <p> Transparent Gray</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 white-swatch-dark">
-//                       <p>$white <br>#424242</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 gray-012-swatch-dark">
-//                       <p>$gray012 #303030</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 gray-026-swatch-dark">
-//                      <p>$gray026 rgba(0,0,0,0.26)</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 gray-054-swatch-dark">
-//                       <p class="white-color-text">$gray054 rgba(107, 107, 107, 1)</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 gray-087-swatch-dark">
-//                       <p class="white-color-text">$gray087 #d1d1d1</p>
-//                 </li>
-//               </ul>
-//            <p> Solid gray</p>
-//               <ul class="swatch-list">
-//                 <li class="spacer material-depth-1 gray-300-swatch-dark">
-//                       <p>$gray-300 #555555</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 gray-500-swatch-dark">
-//                       <p  class="white-color-text">$gray-500 #9E9E9E</p>
-//                 </li>
-//                 <li class="spacer material-depth-1 gray-100-swatch-dark">
-//                       <p class="white-color-text">$gray100 #c2e085</p>
-//                 </li>
-//               </ul>
-//             </div>
-//           </div>
-//         </md-content>
-//       </md-tab>
-//     </md-tabs>
-//     </md-content>
+//                 <div class="con-flex">
+//                  <div class="con-fluid-row swatch-list">
+//                    <div class="con-fluid-flex" style="border:none" ng-repeat="swatch in classicSwatches">
+//                      <div class="card panel swatch">
+//                        <div ng-class="swatch.DarkClass">
+//                          <div class="spacer"></div>
+//                        </div>
+//                        <div class="card-footer con-row" style="background:#424242">
+//                          <div class="con-flex">
+//                            <article>
+//                              <b ng-bind="swatch.Variable"></b></br>
+//                              Used for <span ng-bind="swatch.Use"></span></br>
+//                              Code: <span ng-bind="swatch.DarkColor"></span> </br>
+//                              Text color: <span ng-bind="swatch.DarkTextColor"></span>
+//                            </article>
+//                          </div>
+//                        </div>
+//                      </div>
+//                    </div>
+//                   </div>
+//               </div>
+//           </md-content>
+//           </md-tab>
+//         </md-tabs>
+//      </md-content>
 //   </div>
-//   </div>
+// </div>
 //
 //Styleguide 3.1
 //

--- a/css/_datepicker.scss
+++ b/css/_datepicker.scss
@@ -19,28 +19,34 @@
 //<tr><td>custom-validators</td><td>Define additional validations. The value should be an array of validator-definition objects, which should have <code>key</code>, <code>message</code>, and <code>validate</code> properties defined. The <code>validate</code> attribute must be a function that accepts <code>startDate</code> and <code>endDate</code> as input and returns a boolean to indicate validation result.</td><td>false</td></tr>
 //</table>
 //
-//</br>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['datepicker1'] = !showJs['datepicker1']">
+//       <span ng-hide="showJs['datepicker1']">Show</span>
+//      <span ng-show="showJs['datepicker1']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['datepicker1']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
-//$scope.dateRange = {
-//    startDate: new Date(),
-//    endDate: new Date()
-//};
-//$scope.dateRangeTemplateType = 'inline';
-//$scope.dateRangeTemplateTypes = ['popup', 'inline'];
-//$scope.dateRangeCustomValidators = [{
-//    key: 'lessThan7Days',
-//    message: 'DateRangeMustBeLessThanSevenDays',
-//    validate: function(start, end) {
-//        return moment(end).diff(moment(start), 'days') <= 7;
-//    }
-//}];
-//		</pre></code>
-//	</div>
-//</div>
+// $scope.dateRange = {
+//	 startDate: new Date(),
+//	 endDate: new Date()
+// };
+// $scope.dateRangeTemplateType = 'inline';
+// $scope.dateRangeTemplateTypes = ['popup', 'inline'];
+// $scope.dateRangeCustomValidators = [{
+// 	key: 'lessThan7Days',
+// 	message: 'DateRangeMustBeLessThanSevenDays',
+// 	validate: function(start, end) {
+// 		return moment(end).diff(moment(start), 'days') <= 7;
+// 	}
+// }];
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //
 //Markup: dateRangePicker.hbs
@@ -111,10 +117,10 @@
 }
 
 .glyphicon-chevron-left:before {
-    content: "«"!important;
+	content: "«"!important;
 }
 .glyphicon-chevron-right:before {
-    content: "»"!important;
+	content: "»"!important;
 }
 
 .wfm-datepicker{

--- a/css/_form.scss
+++ b/css/_form.scss
@@ -335,10 +335,43 @@ md-select {
 // Skill picker
 //
 // The skill picker is used to switch between selected skills and selected skill groups.
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//	<code><pre>
+//<table class="wfm-table">
+//	<thead>
+//		<tr>
+//			<th>Attribute Name</th>
+//			<th>Usage</th>
+//		</tr>
+//	</thead>
+//	<tbody>
+//		<tr>
+//			<td>skills</td>
+//			<td>Model for binding skills</td>
+//		</tr>
+//		<tr>
+//			<td>skill-areas</td>
+//			<td>Model for binding skill groups</td>
+//		</tr>
+//    <tr>
+//      <td>item-to-return</td>
+//      <td>The currently selected item (skill or group) returned as a callback function</td>
+//    </tr>
+//    <tr>
+//      <td>preselected</td>
+//      <td>Send in a item to be preselected on load</td>
+//    </tr>
+//	</tbody>
+//</table>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['skillPicker'] = !showJs['skillPicker']">
+//       <span ng-hide="showJs['skillPicker']">Show</span>
+//      <span ng-show="showJs['skillPicker']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['skillPicker']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //vm.mockSkills = [
 //  {
 //    Id: 'XYZ',
@@ -377,35 +410,10 @@ md-select {
 //   $scope.filterOutput = selectedItem;
 //}
 //};
-//		</pre></code>
-//	</div>
-//</div>
-//<table class="wfm-table">
-//	<thead>
-//		<tr>
-//			<th>Attribute Name</th>
-//			<th>Usage</th>
-//		</tr>
-//	</thead>
-//	<tbody>
-//		<tr>
-//			<td>skills</td>
-//			<td>Model for binding skills</td>
-//		</tr>
-//		<tr>
-//			<td>skill-areas</td>
-//			<td>Model for binding skill groups</td>
-//		</tr>
-//    <tr>
-//      <td>item-to-return</td>
-//      <td>The currently selected item (skill or group) returned as a callback function</td>
-//    </tr>
-//    <tr>
-//      <td>preselected</td>
-//      <td>Send in a item to be preselected on load</td>
-//    </tr>
-//	</tbody>
-//</table>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 // Markup:
 //<skill-picker skills="mockSkills" skill-areas="mockedSkillGroups" item-to-return="output" preselected-item="preselected"></skill-picker>
@@ -502,14 +510,22 @@ md-autocomplete[disabled]:not([md-floating-label]),
 //
 // Radio buttons are a group of options that can only have one item selected at a time.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['radio'] = !showJs['radio']">
+//       <span ng-hide="showJs['radio']">Show</span>
+//      <span ng-show="showJs['radio']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['radio']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //	  $scope.demos = [{id: '1'}, {id: '2'}, {id: '3'}, {id: '4'}];
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup:
 //<h3>Simple (<span ng-bind="data1"></span>)</h3>
@@ -588,14 +604,22 @@ md-radio-group .md-checked .md-on {
 //
 //Checkboxes are used for selecting multiple input options.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['check'] = !showJs['check']">
+//       <span ng-hide="showJs['check']">Show</span>
+//      <span ng-show="showJs['check']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['check']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //	  $scope.demos = [{id: '1'}, {id: '2'}, {id: '3'}, {id: '4'}];
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup:
 //  <h3>Simple</h3>
@@ -893,10 +917,17 @@ wfm-multiple-search-input{
 //
 //Note: The header text is translated in the project but the names of the inputs needs to be translated using $translate.instant() in the controller.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['advSearch'] = !showJs['advSearch']">
+//       <span ng-hide="showJs['advSearch']">Show</span>
+//      <span ng-show="showJs['advSearch']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['advSearch']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.searchOptions = {
 //    keyword: '',
 //    searchKeywordChanged: false,
@@ -905,9 +936,10 @@ wfm-multiple-search-input{
 //      'option1','option2','option3','option4','option5','option6'
 //    ]
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup: multiple-search.hbs
 //

--- a/css/_modal.scss
+++ b/css/_modal.scss
@@ -73,17 +73,25 @@
 //
 // Note: In all modals and panels the footer links should be buttons, not  &lt;a/&gt; tags.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
-//    	$scope.modalShown = false;
-//    	$scope.toggleModal = function() {
-//      	$scope.modalShown = !$scope.modalShown;
-//    	};
-//		</pre></code>
-//	</div>
-//</div>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['modal1'] = !showJs['modal1']">
+//       <span ng-hide="showJs['modal1']">Show</span>
+//      <span ng-show="showJs['modal1']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['modal1']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
+// $scope.modalShown = false;
+// $scope.toggleModal = function() {
+// 	$scope.modalShown = !$scope.modalShown;
+// };
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup:
 //	<button ng-click='toggleModal()' class="wfm-btn wfm-btn-default">Open modal</button>

--- a/css/_notices.scss
+++ b/css/_notices.scss
@@ -11,16 +11,24 @@
 // A notice should either self-destruct on state change, when timeout is up or be dismissable to free up space. The Notice service methods take 3 arguments: content, timeToLive and destroyOnStateChange.
 // When creating a new notice you will get a notice object. You can destroy the notice by calling notice.destroy().
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['notice'] = !showJs['notice']">
+//       <span ng-hide="showJs['notice']">Show</span>
+//      <span ng-show="showJs['notice']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['notice']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.displaySuccess = function() {
 //		NoticeService.success(message, 5000, true);
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 // Markup: notices.hbs
 //

--- a/css/_pagination.scss
+++ b/css/_pagination.scss
@@ -6,19 +6,26 @@
 //<tr><td>pagination-options</td><td>configurations about the pagination, it contains two properties. "pageNumber" is the current page number; "totalPages" is hwo many pages it sets.</td><td>true</td></tr>
 //<tr><td>get-data-for-page-callback</td><td>this is the function which is used by the directive to call to get the data for a given page number.</td><td>true</td></tr>
 //</table>
-//</br>
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['pagination'] = !showJs['pagination']">
+//       <span ng-hide="showJs['pagination']">Show</span>
+//      <span ng-show="showJs['pagination']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['pagination']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.paginationOptions = {pageNumber: 1, totalPages: 7};
 //$scope.getPageData = function(pageIndex) {
 //    angular.log(pageIndex);
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup:
 //<wfm-pagination class="pull-pagination" pagination-options="paginationOptions" get-data-for-page-callback="getPageData"></wfm-pagination>

--- a/css/_rightpanel.scss
+++ b/css/_rightpanel.scss
@@ -2,10 +2,17 @@
 //
 //The sub header of a regular panel can be repaced to provide a sidebar within the panel.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['sidebar'] = !showJs['sidebar']">
+//       <span ng-hide="showJs['sidebar']">Show</span>
+//      <span ng-show="showJs['sidebar']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['sidebar']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.rightPanelOptions = {
 //		panelState: false,
 //		sidePanelTitle: 'Side panel title',
@@ -14,9 +21,10 @@
 //		showBackdrop: true,
 //		showPopupButton: true
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 // Markup:
 //<div class="panel material-depth-1">

--- a/css/_tables.scss
+++ b/css/_tables.scss
@@ -101,10 +101,17 @@ table{
 //
 //The big table is used to give data more space and actions. Check out the <a href="http://ui-grid.info/docs/#/tutorial">documentation</a> to see all available functions.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['bigTable'] = !showJs['bigTable']">
+//       <span ng-hide="showJs['bigTable']">Show</span>
+//      <span ng-show="showJs['bigTable']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['bigTable']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //var data = [];
 //for (var i = 0; i < 100; i++) {
 //		data[i] = {};
@@ -124,9 +131,10 @@ table{
 //		data: data,
 //};
 //$scope.gridOptions.enableGridMenu = true;
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 // Markup: bigtables.hbs
 //

--- a/css/_tree.scss
+++ b/css/_tree.scss
@@ -8,17 +8,25 @@
 //A tree structure is used to show relations between different items. Selected items are marked with a checkmark and a background along with a left side border. Each tree line has a right align span child that could show an icon if the line is selected.
 //Please note thet the "ng-bind" span should be replaced with the normal angular binding.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['tree'] = !showJs['tree']">
+//       <span ng-hide="showJs['tree']">Show</span>
+//      <span ng-show="showJs['tree']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['tree']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.treeDemos =   [
 //		{categories: [{name: 'item 1'}, {name: 'item 2'}, {name: 'item 3'}, {name: 'item 2'}], name: 'First Group',},
 //		{categories: [{name: 'item 1'}, {name: 'item 3'}], name: 'Second Group'}, {categories: [], name: 'Third Group'}
 //];
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //  Markup: tree.hbs
 //

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -948,6 +948,7 @@ body{
   z-index:9;
   max-height: 100%;
   overflow-y: auto;
+  padding: 0;
 }
 .kss-sidebar-hidden{
   visibility: hidden;
@@ -955,6 +956,25 @@ body{
 #kss-node .kss-title__permalink {
   font-size: 30px;
   font-weight: normal;
+}
+.kss-header{
+  margin: 0!important;
+  padding: 1rem;
+}
+.kss-nav__menu-item{
+  padding: 0.5rem;
+
+  a{
+    color: $text-color-standard!important;
+  }
+}
+
+.kss-nav__menu-child{
+  background: $gray012;
+  .kss-nav__menu-item:hover{
+  background: $gray012!important;
+  }
+
 }
 
 .section-hero{
@@ -964,15 +984,19 @@ body{
   position: relative;
 
   .kss-style{
+    color: white!important;
+
+    a{
       color: white!important;
+    }
 
-      a{
-        color: white!important;
-      }
+    h1{
+      text-shadow: 0 2px 5px rgba(0,0,0,.26);
+    }
 
-      .kss-title__ref{
-        display: none!important;
-      }
+    .kss-title__ref{
+      display: none!important;
+    }
   }
 }
 
@@ -1001,7 +1025,7 @@ body{
     overflow-y: auto;
   }
   #kss-node .kss-section {
-    max-width: 80%;
+    max-width: 98%;
   }
 }
 
@@ -1052,11 +1076,11 @@ md-tooltip {
   transform: scale(0.9);
 }
 .swatch-list {
-.spacer{
-  width: 100%;
-  height: 100px;
-  background: transparent!important;
-}
+  .spacer{
+    width: 100%;
+    height: 100px;
+    background: transparent!important;
+  }
 
   .blue-500-swatch {
     background:$blue-500!important;

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -945,7 +945,7 @@ body{
   background: white;
   top: 0;
   left: 0;
-  z-index:9;
+  z-index:90;
   max-height: 100%;
   overflow-y: auto;
   padding: 0;

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -961,11 +961,23 @@ body{
   margin: 0!important;
   padding: 1rem;
 }
-.kss-nav__menu-item{
-  padding: 0.5rem;
 
-  a{
+.kss-nav__menu-item {
+  padding: 0.5rem;
+  a {
     color: $text-color-standard!important;
+  }
+}
+
+.kss-nav__menu > .kss-nav__menu-item {
+  padding: 0;
+  & > a {
+    display: block;
+    height: 100%;
+    padding: 0.5rem;
+  }
+  & > a:hover {
+    background: $gray012;
   }
 }
 

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -599,18 +599,26 @@
 //In case you want to guide the user through a series of steps you can use a wizard panel.
 //
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['wiz'] = !showJs['wiz']">
+//       <span ng-hide="showJs['wiz']">Show</span>
+//      <span ng-show="showJs['wiz']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['wiz']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.selectedIndex = 0;
 //$scope.nextTab = function() {
 //  var index = ($scope.selectedIndex === 50) ? 0 : $scope.selectedIndex + 1;
 //  $scope.selectedIndex = index;
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup:
 //<div class="panel material-depth-1">
@@ -687,19 +695,27 @@
 
 //Basic Form panel
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['form2'] = !showJs['form2']">
+//       <span ng-hide="showJs['form2']">Show</span>
+//      <span ng-show="showJs['form2']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['form2']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.reset = function(form) {
 //  if (form) {
 //    form.$setPristine();
 //    form.$setUntouched();
 //  }
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Markup: form_panel.hbs
 //
@@ -710,19 +726,27 @@
 //
 //Dividing the inputs into different sub-categories using headers can make the structure more clear.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['form3'] = !showJs['form3']">
+//       <span ng-hide="showJs['form3']">Show</span>
+//      <span ng-show="showJs['form3']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['form3']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.reset = function(form) {
 //  if (form) {
 //    form.$setPristine();
 //    form.$setUntouched();
 //  }
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 // Markup: form2_panel.hbs
 //
@@ -733,19 +757,27 @@
 //
 //The layout inside the form can be changed to give more space to certain parts, just remember to structure the inputs in a logical way.
 //
-//<div class="jsprewrap">
-//	<div ng-click="showjs = !showjs" class="ksscopy">JavaScript</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['form4'] = !showJs['form4']">
+//       <span ng-hide="showJs['form4']">Show</span>
+//      <span ng-show="showJs['form4']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['form4']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 //$scope.reset = function(form) {
 //  if (form) {
 //    form.$setPristine();
 //    form.$setUntouched();
 //  }
 //};
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 // Markup: form3_panel.hbs
 //
@@ -771,10 +803,17 @@
 //
 //Note: "config" cannot be used as a child state name.
 //
-//<div class="jsprewrap">
-//	<div ng-cloak ng-click="showjs = !showjs" class="ksscopy">Example</div>
-//	<div ng-show="showjs">
-//		<code><pre>
+// <div class="jsprewrap">
+//   <div class="ksscopy kss-style" ng-click="showJs['states'] = !showJs['states']">
+//       <span ng-hide="showJs['states']">Show</span>
+//      <span ng-show="showJs['states']">Hide</span>
+//     JavaScript
+//     <i class="mdi mdi-code-tags pull-right"></i>
+//   </div>
+//   <div class="animate-show" ng-show="showJs['states']">
+//     <code>
+//       <pre class="prettyprint linenums lang-js">
+//
 // function stateConfig($stateProvider) {
 //   $stateProvider.state('example',
 //   {
@@ -795,9 +834,10 @@
 //     controller: 'ExampleSecondViewController'
 //   })
 // }
-//		</pre></code>
-//	</div>
-//</div>
+//       </pre>
+//     </code>
+//   </div>
+// </div>
 //
 //Styleguide 9.1
 
@@ -859,6 +899,11 @@
 
 html{
   overflow-y: auto!important;
+  background: rgb(235, 235, 235)!important;
+}
+
+body{
+  background: transparent!important;
 }
 
 .spacer {
@@ -869,36 +914,55 @@ html{
   background: white;
 }
 
-.jsprewrap{
-  width: 98%;
-  margin: 0 auto;
-  cursor:pointer;
-}
-
 .con-flex,.form-input-wrap, .con-fluid-flex{
   border:1px dashed $gray026;
 }
 
 .ksscopy{
-  margin: -10px -10px 10px -10px;
   padding: 10px;
-  border: 1px solid #ccc;
-  background-color: #eee;
+  border-bottom: 1px solid #ccc;
   font-weight: bold;
+  cursor: pointer;
+  background: rgba(0,0,0,0.06);
+}
+
+.kss-modifier__wrapper{
+  border: none!important;
 }
 
 /*template styles*/
 .kss-sidebar {
   position:fixed!important;
 }
-
+.sidebar-toggle{
+  position: fixed!important;
+  top: 20px;
+  left: 0px;
+  z-index: 100;
+  background: white!important;
+}
+#kss-node .kss-sidebar {
+  background: white;
+  top: 0;
+  left: 0;
+  z-index:9;
+  max-height: 100%;
+  overflow-y: auto;
+}
+.kss-sidebar-hidden{
+  visibility: hidden;
+}
 #kss-node .kss-title__permalink {
   font-size: 30px;
   font-weight: normal;
 }
 
-#kss-node .kss-section {
-  max-width: 80%;
+.section-hero{
+  color: white!important;
+  background: #0099FF!important;
+  outline: 420px solid #0099FF;
+  z-index: -1;
+  position: relative;
 }
 
 .kss-style code {
@@ -910,23 +974,27 @@ html{
 #kss-node ol.linenums li {
   border:none;
 }
-
-#kss-node .kss-sidebar {
+#kss-node .kss-section{
+  max-width: 100%;
   background: white;
-  top: 0;
-  z-index:9;
-  max-height: 100%;
-  overflow-y: auto;
+  padding: 0.5rem;
 }
-
 @media screen and (min-width: 769px){
   #kss-node .kss-sidebar {
     background: white;
     top: 0;
+    bottom: 0;
     z-index:9;
     max-height: 100%;
     overflow-y: auto;
   }
+  #kss-node .kss-section {
+    max-width: 80%;
+  }
+}
+
+li.L0 > span:nth-child(1){
+  display: none!important;
 }
 
 .styleguide-break{
@@ -950,16 +1018,33 @@ md-tooltip {
 .darktheme-background {
   background: #303030 !important;
   color: rgba(255,255,255,0.87)!important;
+  overflow-x: hidden;
+
+  article{
+    color: #d1d1d1;
+  }
 }
+
+
 
 .classictheme-background {
   background: $gray012 !important;
   color: $text-color-standard;
+  overflow-x: hidden;
 }
 
 
 //Color swatches
+.swatch{
+  transform-origin: center;
+  transform: scale(0.9);
+}
 .swatch-list {
+.spacer{
+  width: 100%;
+  height: 100px;
+  background: transparent!important;
+}
 
   .blue-500-swatch {
     background:$blue-500!important;
@@ -1225,18 +1310,17 @@ md-tooltip {
 
   li{
     position:relative;
-    width: 100px;
-    height: 100px;
+    height: 250px;
+    text-align: left;
 
-    .white-color-text{
-      color:$white;
-    }
-
-    p{
+    article{
       left:0;
       right:0;
       bottom:0;
       position:absolute;
+      background: $white;
+      height: 100px;
+      padding: 10px;
     }
   }
 }

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -958,11 +958,22 @@ body{
 }
 
 .section-hero{
-  color: white!important;
   background: #0099FF!important;
   outline: 420px solid #0099FF;
   z-index: -1;
   position: relative;
+
+  .kss-style{
+      color: white!important;
+
+      a{
+        color: white!important;
+      }
+
+      .kss-title__ref{
+        display: none!important;
+      }
+  }
 }
 
 .kss-style code {
@@ -978,6 +989,7 @@ body{
   max-width: 100%;
   background: white;
   padding: 0.5rem;
+  margin-bottom: 2rem!important;
 }
 @media screen and (min-width: 769px){
   #kss-node .kss-sidebar {

--- a/css/tree.hbs
+++ b/css/tree.hbs
@@ -16,7 +16,9 @@
 
 <script type="text/ng-template" id="item_renderer.html">
 	<div class="tree-toggle-group">
-		<div class="toggle-handle" ng-class="{open: item.show}" ng-click="item.show = !item.show"><i ng-show="item.categories.length > 0" class="mdi mdi-chevron-right"></i></div>
+		<div class="toggle-handle" ng-class="{open: item.show}" ng-click="item.show = !item.show">
+			<i ng-show="item.categories.length > 0" class="mdi mdi-chevron-right"></i>
+		</div>
 		<div ui-tree-handle ng-class="{selected: item.selected}" ng-click="item.selected=!item.selected">
 			<span ng-bind="item.name"></span>
 			<span class="tree-line-right"><i class="mdi mdi-check"></i></span>

--- a/js/app.js
+++ b/js/app.js
@@ -284,7 +284,329 @@
         }, 5000 );
       }
 
-
+      // color list
+      $scope.classicSwatches = [
+        {
+          Variable: '$blue-100',
+          Color: '#99D6FF',
+          Class: 'blue-100-swatch',
+          DarkColor: '#1d5a83',
+          DarkClass: 'blue-100-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'highlights'
+        },
+        {
+          Variable: '$blue-300',
+          Color: '#66C2FF',
+          Class: 'blue-300-swatch',
+          DarkColor: '#136fac',
+          DarkClass: 'blue-300-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'secondary actions'
+        },
+        {
+          Variable: '$blue-500',
+          Color: '#0099FF',
+          Class: 'blue-500-swatch',
+          DarkColor: '#0a84d6',
+          DarkClass: 'blue-500-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'primary actions'
+        },
+        {
+          Variable: '$orange-400',
+          Color: '#FFC285',
+          Class: 'orange-400-swatch',
+          DarkColor: '#c27c36',
+          DarkClass: 'orange-400-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'warnings'
+        },
+        {
+          Variable: '$orange-500',
+          Color: '#FFA726',
+          Class: 'orange-500-swatch',
+          DarkColor: '#d68636',
+          DarkClass: 'orange-500-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'warnings'
+        },
+        {
+          Variable: '$orange-600',
+          Color: '#FB8C00',
+          Class: 'orange-600-swatch',
+          DarkColor: '#ea9036',
+          DarkClass: 'orange-600-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'warnings'
+        },
+        {
+          Variable: '$red-600',
+          Color: '#EE8F7D',
+          Class: 'red-600-swatch',
+          DarkColor: '#ca3333',
+          DarkClass: 'red-600-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'errors'
+        },
+        {
+          Variable: '$red-700',
+          Color: '#EF5350',
+          Class: 'red-700-swatch',
+          DarkColor: '#EF5350',
+          DarkClass: 'red-700-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'errors'
+        },
+        {
+          Variable: '$red-800',
+          Color: '#D32F2F',
+          Class: 'red-800-swatch',
+          DarkColor: '#ee8f7d',
+          DarkClass: 'red-800-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'errors'
+        },
+        {
+          Variable: '$green-100',
+          Color: '#C2E085',
+          Class: 'green-100-swatch',
+          DarkColor: '#627b32',
+          DarkClass: 'green-100-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'selection and success'
+        },
+        {
+          Variable: '$green-300',
+          Color: '#9CCC65',
+          Class: 'green-300-swatch',
+          DarkColor: '#6f8e32',
+          DarkClass: 'green-300-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'selection and success'
+        },
+        {
+          Variable: '$green-500',
+          Color: '#8BC34A',
+          Class: 'green-500-swatch',
+          DarkColor: '#84ad32',
+          DarkClass: 'green-500-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'selection and success'
+        },
+        {
+          Variable: '$pink-100',
+          Color: '#F8BBD0',
+          Class: 'pink-100-swatch',
+          DarkColor: '#E91E63',
+           DarkClass: 'pink-100-swatch-dark',
+           DarkTextColor: '$text-color-standard',
+           TextColor: '$text-color-standard',
+          Use: 'loading'
+        },
+        {
+          Variable: '$pink-300',
+          Color: '#F06292',
+          Class: 'pink-300-swatch',
+          DarkColor: '#F06292',
+          DarkClass: 'pink-300-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$white',
+          Use: 'loading'
+        },
+        {
+          Variable: '$pink-500',
+          Color: '#E91E63',
+          Class: 'pink-500-swatch',
+          DarkColor: '#F8BBD0',
+          DarkClass: 'pink-500-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'loading'
+        },
+        {
+          Variable: '$purple-100',
+          Color: '#E1BEE7',
+          Class: 'purple-100-swatch',
+          DarkColor: '#9C27B0',
+          DarkClass: 'purple-100-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'priority'
+        },
+        {
+          Variable: '$purple-300',
+          Color: '#BA68C8',
+          Class: 'purple-300-swatch',
+          DarkColor: '#BA68C8',
+          DarkClass: 'purple-300-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$white',
+          Use: 'priority'
+        },
+        {
+          Variable: '$purple-500',
+          Color: '#9C27B0',
+          Class: 'purple-500-swatch',
+          DarkColor: '#E1BEE7',
+          DarkClass: 'purple-500-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'priority'
+        },
+        {
+          Variable: '$teal-100',
+          Color: '#B2DFDB',
+          Class: 'teal-100-swatch',
+          DarkColor: '#009688',
+          DarkClass: 'teal-100-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'flavor'
+        },
+        {
+          Variable: '$teal-300',
+          Color: '#4DB6AC',
+          Class: 'teal-300-swatch',
+          DarkColor: '#4DB6AC',
+          DarkClass: 'teal-300-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$text-color-standard',
+          Use: 'flavor'
+        },
+        {
+          Variable: '$teal-500',
+          Color: '#009688',
+          Class: 'teal-500-swatch',
+          DarkColor: '#B2DFDB',
+          DarkClass: 'teal-500-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'flavor'
+        },
+        {
+          Variable: '$brown-100',
+          Color: '#D7CCC8',
+          Class: 'brown-100-swatch',
+          DarkColor: '#795548',
+          DarkClass: 'brown-100-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'flavor'
+        },
+        {
+          Variable: '$brown-300',
+          Color: '#A1887F',
+          Class: 'brown-300-swatch',
+          DarkColor: '#A1887F',
+          DarkClass: 'brown-300-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'flavor'
+        },
+        {
+          Variable: '$brown-500',
+          Color: '#795548',
+          Class: 'brown-500-swatch',
+          DarkColor: '#D7CCC8',
+          DarkClass: 'brown-500-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'flavor'
+        },
+        {
+          Variable: '$white',
+          Color: '#ffffff',
+          Class: 'white-swatch',
+          DarkColor: '#424242',
+          DarkClass: 'white-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'backgrounds and highlights'
+        },
+        {
+          Variable: '$gray-300',
+          Color: '#E0E0E0',
+          Class: 'gray-300-swatch',
+          DarkColor: '#555555',
+          DarkClass: 'gray-300-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$white',
+          Use: 'solid hover'
+        },
+        {
+          Variable: '$gray012',
+          Color: 'rgba(0,0,0,0.06)',
+          Class: 'gray-012-swatch',
+          DarkColor: '#303030',
+          DarkClass: 'gray-012-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'hovers and backgrounds'
+        },
+        {
+          Variable: '$gray026',
+          Color: 'rgba(0,0,0,0.26)',
+          Class: 'gray-026-swatch',
+          DarkColor: 'rgba(0,0,0,0.26)',
+          DarkClass: 'gray-026-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'disabled actions'
+        },
+        {
+          Variable: '$gray-500',
+          Color: '#9E9E9E',
+          Class: 'gray-500-swatch',
+          DarkColor: '#9E9E9E',
+          DarkClass: 'gray-500-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$text-color-standard',
+          Use: 'solid disabled'
+        },
+        {
+          Variable: '$gray054',
+          Color: 'rgba(0,0,0,0.54)',
+          Class: 'gray-054-swatch',
+          DarkColor: 'rgba(107, 107, 107, 1)',
+          DarkClass: 'gray-054-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$white',
+          Use: 'flavor'
+        },
+        {
+          Variable: '$gray087',
+          Color: 'rgba(0,0,0,0.87)',
+          Class: 'gray-087-swatch',
+          DarkColor: '#d1d1d1',
+          DarkClass: 'gray-087-swatch-dark',
+          DarkTextColor: '$white',
+          TextColor: '$white',
+          Use: 'text'
+        },
+        {
+          Variable: '$gray100',
+          Color: '#000000',
+          Class: 'gray-100-swatch',
+          DarkColor: '#c2e085',
+          DarkClass: 'gray-100-swatch-dark',
+          DarkTextColor: '$text-color-standard',
+          TextColor: '$white',
+          Use: 'flavor'
+        }
+      ]
 
       $scope.numericValueInput = '12,000';
       $scope.numericValueInputResult = 12000;

--- a/kss-template/index.html
+++ b/kss-template/index.html
@@ -29,9 +29,9 @@
   <md-tooltip>Options</md-tooltip>
 </div> -->
 <div class="kss-sidebar material-depth-2 kss-style" ng-class="{'kss-sidebar-hidden':hideSidebar}">
-  <header class="kss-header">
+  <header class="kss-header line-center">
     <a href="index.html">
-      <img src="http://www.teleopti.com/system/images/teleopti_logo.png" alt="Teleopti logo" height="30px" style="vertical-align:bottom;">
+      <img src="http://www.teleopti.com/system/images/teleopti_logo.png" alt="Teleopti logo" height="60px" style="vertical-align:bottom;">
     </a>
   </header>
   <nav class="kss-nav">
@@ -61,6 +61,7 @@
         </li>
         {{/eachRoot}}
       </ul>
+      <br/>
     </nav>
   </div>
   {{/if}}

--- a/kss-template/index.html
+++ b/kss-template/index.html
@@ -25,235 +25,237 @@
   {{#if homepage}}
   {{else}}
   <!-- <div tabindex=0 class="context-menu card-context sidebar-toggle material-depth-2" ng-click="hideSidebar = !hideSidebar">
-    <i class="mdi mdi-backburger"></i>
-    <md-tooltip>Options</md-tooltip>
-  </div> -->
-  <div class="kss-sidebar material-depth-2 kss-style" ng-class="{'kss-sidebar-hidden':hideSidebar}">
-    <header class="kss-header">
-      <a href="index.html">
-        <img src="http://www.teleopti.com/system/images/teleopti_logo.png" alt="Teleopti logo" height="30px" style="vertical-align:bottom;">
-      </a>
-    </header>
-    <nav class="kss-nav">
-      <ul class="kss-nav__menu">
-        {{#eachRoot}}
-        <li class="kss-nav__menu-item">
-          <a href="section-{{referenceURI}}.html">
-            <span class="kss-nav__ref">{{#ifNumeric reference}}{{reference}}{{else}}{{autoincrement}}{{/ifNumeric}}</span
-              ><span class="kss-nav__name">{{header}}</span>
+  <i class="mdi mdi-backburger"></i>
+  <md-tooltip>Options</md-tooltip>
+</div> -->
+<div class="kss-sidebar material-depth-2 kss-style" ng-class="{'kss-sidebar-hidden':hideSidebar}">
+  <header class="kss-header">
+    <a href="index.html">
+      <img src="http://www.teleopti.com/system/images/teleopti_logo.png" alt="Teleopti logo" height="30px" style="vertical-align:bottom;">
+    </a>
+  </header>
+  <nav class="kss-nav">
+    <ul class="kss-nav__menu">
+      {{#eachRoot}}
+      <li class="kss-nav__menu-item">
+        <a href="section-{{referenceURI}}.html">
+          <i class="mdi" ng-class="getChapteIcon('{{header}}')"></i>
+          <span class="kss-nav__name">{{header}}</span>
+        </a>
+        {{#ifReference ../rootName}}
+        <ul class="kss-nav__menu-child">
+          {{#eachSection reference}}
+          {{#ifDepth 2}}
+          <a href="section-{{../../referenceURI}}.html#kssref-{{referenceURI}}">
+            <li class="kss-nav__menu-item">
+
+              <span class="kss-nav__ref">{{#ifNumeric reference}}{{reference}}{{else}}{{autoincrement}}{{/ifNumeric}}</span
+                ><span class="kss-nav__name">{{header}}</span>
+
+              </li>
             </a>
-            {{#ifReference ../rootName}}
-            <ul class="kss-nav__menu-child">
-              {{#eachSection reference}}
-              {{#ifDepth 2}}
-              <li class="kss-nav__menu-item">
-                <a href="section-{{../../referenceURI}}.html#kssref-{{referenceURI}}">
-                  <span class="kss-nav__ref">{{#ifNumeric reference}}{{reference}}{{else}}{{autoincrement}}{{/ifNumeric}}</span
-                    ><span class="kss-nav__name">{{header}}</span>
-                  </a>
-                </li>
+            {{/ifDepth}}
+            {{/eachSection}}
+          </ul>
+          {{/ifReference}}
+        </li>
+        {{/eachRoot}}
+      </ul>
+    </nav>
+  </div>
+  {{/if}}
+
+  <article role="main">
+    {{#if homepage}}
+    <div ng-cloak id="kssref-0" class="kss-overview">
+
+      <style media="screen">
+      .con-flex{border:none!important}.styleguide-hero{background:#09F;height:40vh}.styleguide-hero h1{font-size:300%;color:#fff;margin:3rem 0!important;text-shadow:0 2px 5px rgba(0,0,0,.26)}.search-result-wrapper{z-index:100;position:relative}#kss-node{padding:0}.homepage-grid{flex-wrap:wrap}.homepage-grid>.homepage-card{min-width:30%;margin:1%}.homepage-card-spacer{height:100px;position:relative;background:url(https://www.toptal.com/designers/subtlepatterns/patterns/seigaiha.png)}.homepage-card-spacer:hover>i{margin-top:-5px}.homepage-card-spacer>i{transition:1s margin ease-in-out;position:absolute;left:0;right:0;top:40%;text-align:center;transform-origin:center;transform:scale(2)}a{text-decoration:none!important;color:rgba(0,0,0,.85)}
+      </style>
+
+      <div class="con-row styleguide-hero">
+        <div class="con-flex"></div>
+        <div class="con-flex x3">
+          <div class="line-center text-white">
+            <h1>Teleopti styleguide</h1>
+            <p>Start exploring by searching for things like panel, buttons and chips.</p>
+            <p>Or navigate to a chapter down below.</p>
+          </div>
+
+          <div class="panel material-depth-1">
+            <div class="con-row">
+              <div class="con-flex">
+                <input autofocus  autocomplete="off" type="text" ng-model="search.Name" placeholder="Search styleguide">
+                {{#eachRoot}}
+                {{#eachSection reference}}
+                {{#ifDepth 2}}
+                <div ng-init="addItemToList('section-{{../../referenceURI}}.html#kssref-{{referenceURI}}', '{{header}}')"></div>
                 {{/ifDepth}}
                 {{/eachSection}}
-              </ul>
-              {{/ifReference}}
-            </li>
-            {{/eachRoot}}
-          </ul>
-        </nav>
-      </div>
-      {{/if}}
-
-      <article role="main">
-        {{#if homepage}}
-        <div ng-cloak id="kssref-0" class="kss-overview">
-
-          <style media="screen">
-          .con-flex{border:none!important}.styleguide-hero{background:#09F;height:40vh}.styleguide-hero h1{font-size:300%;color:#fff;margin:3rem 0!important;text-shadow:0 2px 5px rgba(0,0,0,.26)}.search-result-wrapper{z-index:100;position:relative}#kss-node{padding:0}.homepage-grid{flex-wrap:wrap}.homepage-grid>.homepage-card{min-width:30%;margin:1%}.homepage-card-spacer{height:100px;position:relative;background:url(https://www.toptal.com/designers/subtlepatterns/patterns/seigaiha.png)}.homepage-card-spacer:hover>i{margin-top:-5px}.homepage-card-spacer>i{transition:1s margin ease-in-out;position:absolute;left:0;right:0;top:40%;text-align:center;transform-origin:center;transform:scale(2)}a{text-decoration:none!important;color:rgba(0,0,0,.85)}
-          </style>
-
-          <div class="con-row styleguide-hero">
-            <div class="con-flex"></div>
-            <div class="con-flex x3">
-              <div class="line-center text-white">
-                <h1>Teleopti styleguide</h1>
-                <p>Start exploring by searching for things like panel, buttons and chips.</p>
-                <p>Or navigate to a chapter down below.</p>
+                {{/eachRoot}}
               </div>
+            </div>
+            <div class="con-row search-result-wrapper">
+              <ul class="wfm-list" style="width:100%;" ng-if="search.Name.length>0" ng-cloak>
+                <div ng-repeat="searchItem in menuItems | filter:search as results" ng-bind-html="searchItem.Link"></div>
+                <a ng-hide="results.length" href="https://github.com/Teleopti/styleguide/issues">
+                  <li>Thats not in the styleguide yet! If you want it to be you can click here and add it to our to-do list.</li>
+                </a>
+              </ul>
+            </div>
+          </div>
 
-              <div class="panel material-depth-1">
+        </div>
+        <div class="con-flex"></div>
+      </div>
+
+
+      <div class="con-row">
+        <div class="con-flex"></div>
+        <div class="con-flex x3">
+          <div class="con-row">
+            <div class="con-flex">
+              <h1 class="kss-title__permalink non-pointer">Chapters</h1>
+            </div>
+          </div>
+          <div class="con-row homepage-grid">
+
+            {{#eachRoot}}
+            <div class="con-flex homepage-card material-depth-1">
+              <a href="section-{{referenceURI}}.html">
+                <div class="con-row">
+                  <div class="con-flex homepage-card-spacer">
+                    <i class="mdi" ng-class="getChapteIcon('{{header}}')"></i>
+                  </div>
+                </div>
                 <div class="con-row">
                   <div class="con-flex">
-                    <input autofocus  autocomplete="off" type="text" ng-model="search.Name" placeholder="Search styleguide">
-                    {{#eachRoot}}
-                    {{#eachSection reference}}
-                    {{#ifDepth 2}}
-                    <div ng-init="addItemToList('section-{{../../referenceURI}}.html#kssref-{{referenceURI}}', '{{header}}')"></div>
-                    {{/ifDepth}}
-                    {{/eachSection}}
-                    {{/eachRoot}}
-                  </div>
-                </div>
-                <div class="con-row search-result-wrapper">
-                  <ul class="wfm-list" style="width:100%;" ng-if="search.Name.length>0" ng-cloak>
-                    <div ng-repeat="searchItem in menuItems | filter:search as results" ng-bind-html="searchItem.Link"></div>
-                    <a ng-hide="results.length" href="https://github.com/Teleopti/styleguide/issues">
-                      <li>Thats not in the styleguide yet! If you want it to be you can click here and add it to our to-do list.</li>
-                    </a>
-                  </ul>
-                </div>
-              </div>
-
-            </div>
-            <div class="con-flex"></div>
-          </div>
-
-
-          <div class="con-row">
-            <div class="con-flex"></div>
-            <div class="con-flex x3">
-              <div class="con-row">
-                <div class="con-flex">
-                  <h1 class="kss-title__permalink non-pointer">Chapters</h1>
-                </div>
-              </div>
-              <div class="con-row homepage-grid">
-
-                {{#eachRoot}}
-                <div class="con-flex homepage-card material-depth-1">
-                  <a href="section-{{referenceURI}}.html">
-                    <div class="con-row">
-                      <div class="con-flex homepage-card-spacer">
-                        <i class="mdi" ng-class="getChapteIcon('{{header}}')"></i>
-                      </div>
+                    <h2>{{header}}<h2>
                     </div>
-                    <div class="con-row">
-                      <div class="con-flex">
-                        <h2>{{header}}<h2>
-                        </div>
-                      </div>
-                    </a>
                   </div>
-                  {{/eachRoot}}
-
-                </div>
-              </div>
-              <div class="con-flex"></div>
-            </div>
-          </div>
-        </article>
-        {{else}}
-        <article role="main" class="kss-main">
-          {{!
-            Display each section, in order.
-
-            The "root" element comes first in this loop, and can be detected using
-            the "#ifDepth 1" block as seen below.
-          }}
-          {{#eachSection rootName}}
-          {{#ifDepth 1}}
-          <div id="kssref-{{referenceURI}}" class="kss-section section-hero kss-section--depth-{{depth}}">
-            {{else}}
-            <section id="kssref-{{referenceURI}}" class="kss-section material-depth-1 kss-section--depth-{{depth}}">
-              {{/ifDepth}}
-
-              <div class="kss-style">
-                <h{{depth}} class="kss-title kss-title--level-{{depth}}">
-                <a class="kss-title__permalink">
-                  {{header}}
                 </a>
-              </h{{depth}}>
-              <small class="kss-title__ref">{{#ifNumeric reference}}{{reference}}{{else}}{{autoincrement}}{{/ifNumeric}}</small>
-
-              {{#if parameters}}
-              <ul class="kss-parameters">
-                {{#eachParameter}}
-                <li class="kss-parameters__item">
-                  <code class="kss-parameters__name">{{name}}</code>
-                  <div class="kss-parameters__description">{{{description}}}</div>
-                </li>
-                {{/eachParameter}}
-              </ul>
-              {{/if}}
-
-              {{#if description}}
-              <div class="kss-description">
-                {{{description}}}
               </div>
-              {{/if}}
-            </div>
+              {{/eachRoot}}
 
-            {{#if markup}}
-
-            <div class="jsprewrap" ng-cloak>
-              <div class="ksscopy kss-style" ng-click="markupShow['{{header}}'] = !markupShow['{{header}}']">
-                <span ng-hide="markupShow['{{header}}']">Show</span>
-                <span ng-show="markupShow['{{header}}']">Hide</span>
-                markup
-                <i class="mdi mdi-code-tags pull-right"></i>
-              </div>
-              <div class="animate-show" ng-show="markupShow['{{header}}']">
-                <code>
-                  <pre class="prettyprint linenums lang-html" style="white-space: pre-line;">
-                    {{markup}}
-                  </pre>
-                </code>
-              </div>
             </div>
-
-            <div class="kss-modifier__wrapper">
-              <!-- <div class="kss-modifier__heading kss-style">
-              Example{{#if modifiers}}s{{/if}}
-            </div> -->
-            {{#if modifiers}}
-            <div class="kss-modifier__default-name kss-style">
-              Default styling
-            </div>
-            {{/if}}
-            <div class="kss-modifier__example">
-              {{{markup}}}
-            </div>
-            {{#eachModifier}}
-            <div class="kss-modifier__name kss-style">
-              {{name}}
-            </div>
-            <div class="kss-modifier__description kss-style">
-              {{{description}}}
-            </div>
-            <div class="kss-modifier__example">
-              {{{markup}}}
-            </div>
-            {{/eachModifier}}
           </div>
+          <div class="con-flex"></div>
+        </div>
+      </div>
+    </article>
+    {{else}}
+    <article role="main" class="kss-main">
+      {{!
+        Display each section, in order.
 
+        The "root" element comes first in this loop, and can be detected using
+        the "#ifDepth 1" block as seen below.
+      }}
+      {{#eachSection rootName}}
+      {{#ifDepth 1}}
+      <div id="kssref-{{referenceURI}}" class="kss-section section-hero kss-section--depth-{{depth}}">
+        {{else}}
+        <section id="kssref-{{referenceURI}}" class="kss-section material-depth-1 kss-section--depth-{{depth}}">
+          {{/ifDepth}}
 
+          <div class="kss-style">
+            <h{{depth}} class="kss-title kss-title--level-{{depth}}">
+            <a class="kss-title__permalink">
+              {{header}}
+            </a>
+          </h{{depth}}>
+          <small class="kss-title__ref">{{#ifNumeric reference}}{{reference}} {{else}}{{autoincrement}}{{/ifNumeric}}</small>
+
+          {{#if parameters}}
+          <ul class="kss-parameters">
+            {{#eachParameter}}
+            <li class="kss-parameters__item">
+              <code class="kss-parameters__name">{{name}}</code>
+              <div class="kss-parameters__description">{{{description}}}</div>
+            </li>
+            {{/eachParameter}}
+          </ul>
           {{/if}}
 
-          {{#ifDepth 1}}
+          {{#if description}}
+          <div class="kss-description">
+            {{{description}}}
+          </div>
+          {{/if}}
         </div>
-        {{else}}
-      </section>
-      {{/ifDepth}}
-      {{/eachSection}}
+
+        {{#if markup}}
+
+        <div class="jsprewrap" ng-cloak>
+          <div class="ksscopy kss-style" ng-click="markupShow['{{header}}'] = !markupShow['{{header}}']">
+            <span ng-hide="markupShow['{{header}}']">Show</span>
+            <span ng-show="markupShow['{{header}}']">Hide</span>
+            markup
+            <i class="mdi mdi-code-tags pull-right"></i>
+          </div>
+          <div class="animate-show" ng-show="markupShow['{{header}}']">
+            <code>
+              <pre class="prettyprint linenums lang-html" style="white-space: pre-line;">
+                {{markup}}
+              </pre>
+            </code>
+          </div>
+        </div>
+
+        <div class="kss-modifier__wrapper">
+          <!-- <div class="kss-modifier__heading kss-style">
+          Example{{#if modifiers}}s{{/if}}
+        </div> -->
+        {{#if modifiers}}
+        <div class="kss-modifier__default-name kss-style">
+          Default styling
+        </div>
+        {{/if}}
+        <div class="kss-modifier__example">
+          {{{markup}}}
+        </div>
+        {{#eachModifier}}
+        <div class="kss-modifier__name kss-style">
+          {{name}}
+        </div>
+        <div class="kss-modifier__description kss-style">
+          {{{description}}}
+        </div>
+        <div class="kss-modifier__example">
+          {{{markup}}}
+        </div>
+        {{/eachModifier}}
+      </div>
+
+
       {{/if}}
-    </article>
 
-    <script src="public/kss.js"></script>
-    <script src="public/prettify.js"></script>
+      {{#ifDepth 1}}
+    </div>
+    {{else}}
+  </section>
+  {{/ifDepth}}
+  {{/eachSection}}
+  {{/if}}
+</article>
 
-    <script>
-    prettyPrint();
-    </script>
+<script src="public/kss.js"></script>
+<script src="public/prettify.js"></script>
 
-    {{{scripts}}}
+<script>
+prettyPrint();
+</script>
 
-    {{! This will only be included in the demo page. }}
-    {{#if argv.xdemo}}
-    <footer class="kss-github">
-      <!-- https://github.com/blog/273-github-ribbons -->
-      <a href="https://github.com/kss-node/kss-node"><img src="public/github-fork--black.png" alt="Fork me on GitHub"></a>
-    </footer>
-    {{/if}}
+{{{scripts}}}
 
-    <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
-  </body>
-  </html>
+{{! This will only be included in the demo page. }}
+{{#if argv.xdemo}}
+<footer class="kss-github">
+  <!-- https://github.com/blog/273-github-ribbons -->
+  <a href="https://github.com/kss-node/kss-node"><img src="public/github-fork--black.png" alt="Fork me on GitHub"></a>
+</footer>
+{{/if}}
+
+<!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
+</body>
+</html>

--- a/kss-template/index.html
+++ b/kss-template/index.html
@@ -24,13 +24,16 @@
 
   {{#if homepage}}
   {{else}}
-  <div class="kss-sidebar kss-style">
-    <a href="index.html" title="Homepage">
-      <header class="kss-header">
+  <!-- <div tabindex=0 class="context-menu card-context sidebar-toggle material-depth-2" ng-click="hideSidebar = !hideSidebar">
+    <i class="mdi mdi-backburger"></i>
+    <md-tooltip>Options</md-tooltip>
+  </div> -->
+  <div class="kss-sidebar material-depth-2 kss-style" ng-class="{'kss-sidebar-hidden':hideSidebar}">
+    <header class="kss-header">
+      <a href="index.html">
         <img src="http://www.teleopti.com/system/images/teleopti_logo.png" alt="Teleopti logo" height="30px" style="vertical-align:bottom;">
-        <h1 class="kss-doc-title">Style Guide</h1>
-      </header>
-    </a>
+      </a>
+    </header>
     <nav class="kss-nav">
       <ul class="kss-nav__menu">
         {{#eachRoot}}
@@ -64,102 +67,102 @@
         {{#if homepage}}
         <div ng-cloak id="kssref-0" class="kss-overview">
 
-        <style media="screen">
-        .con-flex{border:none!important}.styleguide-hero{background:#09F;height:40vh}.styleguide-hero h1{font-size:300%;color:#fff;margin:3rem 0!important;text-shadow:0 2px 5px rgba(0,0,0,.26)}.search-result-wrapper{z-index:100;position:relative}#kss-node{padding:0}.homepage-grid{flex-wrap:wrap}.homepage-grid>.homepage-card{min-width:30%;margin:1%}.homepage-card-spacer{height:100px;position:relative;background:url(https://www.toptal.com/designers/subtlepatterns/patterns/seigaiha.png)}.homepage-card-spacer:hover>i{margin-top:-5px}.homepage-card-spacer>i{transition:1s margin ease-in-out;position:absolute;left:0;right:0;top:40%;text-align:center;transform-origin:center;transform:scale(2)}a{text-decoration:none!important;color:rgba(0,0,0,.85)}
-        </style>
+          <style media="screen">
+          .con-flex{border:none!important}.styleguide-hero{background:#09F;height:40vh}.styleguide-hero h1{font-size:300%;color:#fff;margin:3rem 0!important;text-shadow:0 2px 5px rgba(0,0,0,.26)}.search-result-wrapper{z-index:100;position:relative}#kss-node{padding:0}.homepage-grid{flex-wrap:wrap}.homepage-grid>.homepage-card{min-width:30%;margin:1%}.homepage-card-spacer{height:100px;position:relative;background:url(https://www.toptal.com/designers/subtlepatterns/patterns/seigaiha.png)}.homepage-card-spacer:hover>i{margin-top:-5px}.homepage-card-spacer>i{transition:1s margin ease-in-out;position:absolute;left:0;right:0;top:40%;text-align:center;transform-origin:center;transform:scale(2)}a{text-decoration:none!important;color:rgba(0,0,0,.85)}
+          </style>
 
-        <div class="con-row styleguide-hero">
-          <div class="con-flex"></div>
-          <div class="con-flex x3">
-            <div class="line-center text-white">
-              <h1>Teleopti styleguide</h1>
-              <p>Start exploring by searching for things like panel, buttons and chips.</p>
-              <p>Or navigate to a chapter down below.</p>
-            </div>
-
-            <div class="panel material-depth-1">
-              <div class="con-row">
-                <div class="con-flex">
-                  <input autofocus  autocomplete="off" type="text" ng-model="search.Name" placeholder="Search styleguide">
-                  {{#eachRoot}}
-                  {{#eachSection reference}}
-                  {{#ifDepth 2}}
-                  <div ng-init="addItemToList('section-{{../../referenceURI}}.html#kssref-{{referenceURI}}', '{{header}}')"></div>
-                  {{/ifDepth}}
-                  {{/eachSection}}
-                  {{/eachRoot}}
-                </div>
+          <div class="con-row styleguide-hero">
+            <div class="con-flex"></div>
+            <div class="con-flex x3">
+              <div class="line-center text-white">
+                <h1>Teleopti styleguide</h1>
+                <p>Start exploring by searching for things like panel, buttons and chips.</p>
+                <p>Or navigate to a chapter down below.</p>
               </div>
-              <div class="con-row search-result-wrapper">
-                <ul class="wfm-list" style="width:100%;" ng-if="search.Name.length>0" ng-cloak>
-                  <div ng-repeat="searchItem in menuItems | filter:search as results" ng-bind-html="searchItem.Link"></div>
-                  <a ng-hide="results.length" href="https://github.com/Teleopti/styleguide/issues">
-                    <li>Thats not in the styleguide yet! If you want it to be you can click here and add it to our to-do list.</li>
-                  </a>
-                </ul>
-              </div>
-            </div>
 
-          </div>
-          <div class="con-flex"></div>
-        </div>
-
-
-        <div class="con-row">
-          <div class="con-flex"></div>
-          <div class="con-flex x3">
-            <div class="con-row">
-              <div class="con-flex">
-                <h1 class="kss-title__permalink non-pointer">Chapters</h1>
-              </div>
-            </div>
-            <div class="con-row homepage-grid">
-
-              {{#eachRoot}}
-              <div class="con-flex homepage-card material-depth-1">
-                <a href="section-{{referenceURI}}.html">
-                  <div class="con-row">
-                    <div class="con-flex homepage-card-spacer">
-                      <i class="mdi" ng-class="getChapteIcon('{{header}}')"></i>
-                    </div>
+              <div class="panel material-depth-1">
+                <div class="con-row">
+                  <div class="con-flex">
+                    <input autofocus  autocomplete="off" type="text" ng-model="search.Name" placeholder="Search styleguide">
+                    {{#eachRoot}}
+                    {{#eachSection reference}}
+                    {{#ifDepth 2}}
+                    <div ng-init="addItemToList('section-{{../../referenceURI}}.html#kssref-{{referenceURI}}', '{{header}}')"></div>
+                    {{/ifDepth}}
+                    {{/eachSection}}
+                    {{/eachRoot}}
                   </div>
-                  <div class="con-row">
-                    <div class="con-flex">
-                      <h2>{{header}}<h2>
-                      </div>
-                    </div>
-                  </a>
                 </div>
-                {{/eachRoot}}
-
+                <div class="con-row search-result-wrapper">
+                  <ul class="wfm-list" style="width:100%;" ng-if="search.Name.length>0" ng-cloak>
+                    <div ng-repeat="searchItem in menuItems | filter:search as results" ng-bind-html="searchItem.Link"></div>
+                    <a ng-hide="results.length" href="https://github.com/Teleopti/styleguide/issues">
+                      <li>Thats not in the styleguide yet! If you want it to be you can click here and add it to our to-do list.</li>
+                    </a>
+                  </ul>
+                </div>
               </div>
+
             </div>
             <div class="con-flex"></div>
           </div>
-        </div>
-      </article>
-      {{else}}
-      <article role="main" class="kss-main">
-        {{!
-          Display each section, in order.
 
-          The "root" element comes first in this loop, and can be detected using
-          the "#ifDepth 1" block as seen below.
-        }}
-        {{#eachSection rootName}}
-        {{#ifDepth 1}}
-        <div     id="kssref-{{referenceURI}}" class="kss-section kss-section--depth-{{depth}}">
-          {{else}}
-          <section id="kssref-{{referenceURI}}" class="kss-section kss-section--depth-{{depth}}">
-            {{/ifDepth}}
 
-            <div class="kss-style">
-              <h{{depth}} class="kss-title kss-title--level-{{depth}}">
-              <a class="kss-title__permalink">
-                <span class="kss-title__ref">{{#ifNumeric reference}}{{reference}}{{else}}{{autoincrement}}{{/ifNumeric}}</span
-                  >{{header}}
+          <div class="con-row">
+            <div class="con-flex"></div>
+            <div class="con-flex x3">
+              <div class="con-row">
+                <div class="con-flex">
+                  <h1 class="kss-title__permalink non-pointer">Chapters</h1>
+                </div>
+              </div>
+              <div class="con-row homepage-grid">
+
+                {{#eachRoot}}
+                <div class="con-flex homepage-card material-depth-1">
+                  <a href="section-{{referenceURI}}.html">
+                    <div class="con-row">
+                      <div class="con-flex homepage-card-spacer">
+                        <i class="mdi" ng-class="getChapteIcon('{{header}}')"></i>
+                      </div>
+                    </div>
+                    <div class="con-row">
+                      <div class="con-flex">
+                        <h2>{{header}}<h2>
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                  {{/eachRoot}}
+
+                </div>
+              </div>
+              <div class="con-flex"></div>
+            </div>
+          </div>
+        </article>
+        {{else}}
+        <article role="main" class="kss-main">
+          {{!
+            Display each section, in order.
+
+            The "root" element comes first in this loop, and can be detected using
+            the "#ifDepth 1" block as seen below.
+          }}
+          {{#eachSection rootName}}
+          {{#ifDepth 1}}
+          <div id="kssref-{{referenceURI}}" class="kss-section section-hero kss-section--depth-{{depth}}">
+            {{else}}
+            <section id="kssref-{{referenceURI}}" class="kss-section material-depth-1 kss-section--depth-{{depth}}">
+              {{/ifDepth}}
+
+              <div class="kss-style">
+                <h{{depth}} class="kss-title kss-title--level-{{depth}}">
+                <a class="kss-title__permalink">
+                  {{header}}
                 </a>
               </h{{depth}}>
+              <small class="kss-title__ref">{{#ifNumeric reference}}{{reference}}{{else}}{{autoincrement}}{{/ifNumeric}}</small>
 
               {{#if parameters}}
               <ul class="kss-parameters">
@@ -180,62 +183,77 @@
             </div>
 
             {{#if markup}}
-            <div class="kss-modifier__wrapper">
-              <div class="kss-modifier__heading kss-style">
-                Example{{#if modifiers}}s{{/if}}
+
+            <div class="jsprewrap" ng-cloak>
+              <div class="ksscopy kss-style" ng-click="markupShow['{{header}}'] = !markupShow['{{header}}']">
+                <span ng-hide="markupShow['{{header}}']">Show</span>
+                <span ng-show="markupShow['{{header}}']">Hide</span>
+                markup
+                <i class="mdi mdi-code-tags pull-right"></i>
               </div>
-              {{#if modifiers}}
-              <div class="kss-modifier__default-name kss-style">
-                Default styling
+              <div class="animate-show" ng-show="markupShow['{{header}}']">
+                <code>
+                  <pre class="prettyprint linenums lang-html">
+                    {{markup}}
+                  </pre>
+                </code>
               </div>
-              {{/if}}
-              <div class="kss-modifier__example">
-                {{{markup}}}
-              </div>
-              {{#eachModifier}}
-              <div class="kss-modifier__name kss-style">
-                {{name}}
-              </div>
-              <div class="kss-modifier__description kss-style">
-                {{{description}}}
-              </div>
-              <div class="kss-modifier__example">
-                {{{markup}}}
-              </div>
-              {{/eachModifier}}
             </div>
 
-            <div class="kss-markup kss-style">
-              <pre class="prettyprint linenums lang-html"><code data-language="html">{{markup}}</code></pre>
+            <div class="kss-modifier__wrapper">
+              <!-- <div class="kss-modifier__heading kss-style">
+              Example{{#if modifiers}}s{{/if}}
+            </div> -->
+            {{#if modifiers}}
+            <div class="kss-modifier__default-name kss-style">
+              Default styling
             </div>
             {{/if}}
-
-            {{#ifDepth 1}}
+            <div class="kss-modifier__example">
+              {{{markup}}}
+            </div>
+            {{#eachModifier}}
+            <div class="kss-modifier__name kss-style">
+              {{name}}
+            </div>
+            <div class="kss-modifier__description kss-style">
+              {{{description}}}
+            </div>
+            <div class="kss-modifier__example">
+              {{{markup}}}
+            </div>
+            {{/eachModifier}}
           </div>
-          {{else}}
-        </section>
-        {{/ifDepth}}
-        {{/eachSection}}
-        {{/if}}
-      </article>
 
-      <script src="public/kss.js"></script>
-      <script src="public/prettify.js"></script>
 
-      <script>
-      prettyPrint();
-      </script>
+          {{/if}}
 
-      {{{scripts}}}
-
-      {{! This will only be included in the demo page. }}
-      {{#if argv.xdemo}}
-      <footer class="kss-github">
-        <!-- https://github.com/blog/273-github-ribbons -->
-        <a href="https://github.com/kss-node/kss-node"><img src="public/github-fork--black.png" alt="Fork me on GitHub"></a>
-      </footer>
+          {{#ifDepth 1}}
+        </div>
+        {{else}}
+      </section>
+      {{/ifDepth}}
+      {{/eachSection}}
       {{/if}}
+    </article>
 
-      <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
-    </body>
-    </html>
+    <script src="public/kss.js"></script>
+    <script src="public/prettify.js"></script>
+
+    <script>
+    prettyPrint();
+    </script>
+
+    {{{scripts}}}
+
+    {{! This will only be included in the demo page. }}
+    {{#if argv.xdemo}}
+    <footer class="kss-github">
+      <!-- https://github.com/blog/273-github-ribbons -->
+      <a href="https://github.com/kss-node/kss-node"><img src="public/github-fork--black.png" alt="Fork me on GitHub"></a>
+    </footer>
+    {{/if}}
+
+    <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
+  </body>
+  </html>

--- a/kss-template/index.html
+++ b/kss-template/index.html
@@ -193,7 +193,7 @@
               </div>
               <div class="animate-show" ng-show="markupShow['{{header}}']">
                 <code>
-                  <pre class="prettyprint linenums lang-html">
+                  <pre class="prettyprint linenums lang-html" style="white-space: pre-line;">
                     {{markup}}
                   </pre>
                 </code>


### PR DESCRIPTION
 - Update the rest of the styleguide to follow the look of the startpage
 - Make it clear where each section start and ends using panels
 - Make scroll time shorter by hiding code examples by default
 - Better way of declaring and displaying colors for future ease 
 - Some typos fixed :)

![image](https://user-images.githubusercontent.com/5781286/33653029-e0be9514-da6b-11e7-93f8-8e6d925304b1.png)

![image](https://user-images.githubusercontent.com/5781286/33653050-ee3ba70e-da6b-11e7-8616-8c5ef7b569b6.png)
