### PR TITLE
fix wrong class name

### DIFF
--- a/css/_helpers.scss
+++ b/css/_helpers.scss
@@ -38,7 +38,7 @@
 }
 
 
-.align-row-center{
+.align-row-baseline{
 	display: flex;
 	align-items: baseline;
 }


### PR DESCRIPTION
there were 2 .align-row-center helper classes with different align-items declarations