### PR TITLE
reset tree filter when data changes

### DIFF
--- a/directives/tree-picker/tree.component.js
+++ b/directives/tree-picker/tree.component.js
@@ -142,6 +142,7 @@
             var check = angular.equals(vm.ngModel.$modelValue, vm.data);
             if (!check) {
                 vm.data = vm.ngModel.$modelValue;
+                vm.search = null;
                 $timeout(function () {
                     var selectedItems = $element[0].getElementsByClassName('selected-true');
                     for (var index = 0; index < selectedItems.length; index++) {


### PR DESCRIPTION
The tree filter needs to be reset when the data set changes from parent controller or old filters might be applided resulting in confusing results